### PR TITLE
Order of operation issue with _unmarshal_json_object

### DIFF
--- a/polygon/rest/models/definitions.py
+++ b/polygon/rest/models/definitions.py
@@ -46,7 +46,7 @@ class Definition:
                             model = models.name_to_class[attribute_type]()
                             value = model.unmarshal_json(input_json[key])
             else:
-                attribute_name = key + "_" if keyword.iskeyword(key) else ""
+                attribute_name = key + ('_' if keyword.iskeyword(key) else '')
 
             self.__setattr__(attribute_name, value)
         return self


### PR DESCRIPTION
During an unmarshal the attribute_name was getting set to an empty string. Looks to be an order of operation issue w/ the string append.