### PR TITLE
Fix REST example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ def main():
     key = "your api key"
     client = RESTClient(key)
 
-    resp = client.stocks_equities_daily_open_close("AAPL", "2018-3-2")
+    resp = client.stocks_equities_daily_open_close("AAPL", "2018-03-02")
     print(f"On: {resp.from_} Apple opened at {resp.open} and closed at {resp.close}")
 
 


### PR DESCRIPTION
The REST example does not work without leading zeros on the month and day of the date. I added them and now the example runs correctly.