### PR TITLE
pass RESTClient a timeout in seconds

### DIFF
--- a/polygon/rest/client.py
+++ b/polygon/rest/client.py
@@ -10,12 +10,13 @@ class RESTClient:
     """ This is a custom generated class """
     DEFAULT_HOST = "api.polygon.io"
 
-    def __init__(self, auth_key: str):
+    def __init__(self, auth_key: str, timeout: int=None):
         self.auth_key = auth_key
         self.url = "https://" + self.DEFAULT_HOST
 
         self._session = requests.Session()
         self._session.params["apiKey"] = self.auth_key
+        self.timeout = timeout
 
     def __enter__(self):
         return self
@@ -27,7 +28,7 @@ class RESTClient:
         self._session.close()
 
     def _handle_response(self, response_type: str, endpoint: str, params: Dict[str, str]) -> Type[models.AnyDefinition]:
-        resp: requests.Response = self._session.get(endpoint, params=params)
+        resp: requests.Response = self._session.get(endpoint, params=params, timeout=self.timeout)
         if resp.status_code == 200:
             return unmarshal.unmarshal_json(response_type, resp.json())
         else:


### PR DESCRIPTION
This will throw a `requests.ConnectTimeout` if the timeout is passed before the server responds. I believe the default amount of retries is 3, but I haven't checked.