### PR TITLE
Update Definitions.py to match API Docs

### DIFF
--- a/polygon/rest/models/definitions.py
+++ b/polygon/rest/models/definitions.py
@@ -3046,7 +3046,7 @@ class StocksEquitiesDailyOpenCloseApiResponse(Definition):
         "symbol": "symbol",
         "open": "open",
         "close": "close",
-        "afterHours": "after_hours",
+        "afterHours": "afterHours",
 
     }
 
@@ -3054,7 +3054,7 @@ class StocksEquitiesDailyOpenCloseApiResponse(Definition):
         "symbol": True,
         "open": False,
         "close": False,
-        "after_hours": False,
+        "afterHours": False,
 
     }
 
@@ -3062,7 +3062,7 @@ class StocksEquitiesDailyOpenCloseApiResponse(Definition):
         "symbol": "str",
         "open": "HistTrade",
         "close": "HistTrade",
-        "after_hours": "HistTrade",
+        "afterHours": "HistTrade",
 
     }
 
@@ -3070,7 +3070,7 @@ class StocksEquitiesDailyOpenCloseApiResponse(Definition):
         self.symbol: str
         self.open: HistTrade
         self.close: HistTrade
-        self.after_hours: HistTrade
+        self.afterHours: HistTrade
 
 
 # noinspection SpellCheckingInspection


### PR DESCRIPTION
I was surprised to find that the API Docs are a little off

A simple update find and replace for
`after_hours -> afterHours`

![afterHours](https://user-images.githubusercontent.com/30332451/103919911-7b290f80-50c5-11eb-8f38-98c256611d7d.png)

![Screenshot_2021-01-07_08-43-43](https://user-images.githubusercontent.com/30332451/103919974-8f6d0c80-50c5-11eb-8958-c2e0a2e7b9ea.png)
