### PR TITLE
Fix StocksEquitiesDailyOpenCloseApiResponse type mappings

### DIFF
--- a/polygon/rest/models/definitions.py
+++ b/polygon/rest/models/definitions.py
@@ -3397,8 +3397,8 @@ class StocksEquitiesDailyOpenCloseApiResponse(Definition):
         "low": True,
         "close": True,
         "volume": True,
-        "afterHours": True,
-        "preMarket": True,
+        "after_hours": True,
+        "pre_market": True,
     }
 
     _attributes_to_types = {
@@ -3409,8 +3409,8 @@ class StocksEquitiesDailyOpenCloseApiResponse(Definition):
         "low": "float",
         "close": "float",
         "volume": "float",
-        "afterHours": "float",
-        "preMarket": "float",
+        "after_hours": "float",
+        "pre_market": "float",
     }
 
     def __init__(self):
@@ -3421,8 +3421,8 @@ class StocksEquitiesDailyOpenCloseApiResponse(Definition):
         self.low: float
         self.close: float
         self.volume: float
-        self.afterHours: float
-        self.preMarket: float
+        self.after_hours: float
+        self.pre_market: float
 
 
 # noinspection SpellCheckingInspection


### PR DESCRIPTION
A previous update to the Swagger code created a bug due to the wrong names being put into the type mappings in `StocksEquitiesDailyOpenCloseApiResponse` under the REST models. See #69. 

After running the updated version of the client, I am able to run the user's code successfully:

```py
    with RESTClient(os.environ['API_KEY']) as client:
        resp = client.stocks_equities_daily_open_close("AAPL", "2018-03-02")
        print(f"On: {resp.from_} Apple opened at {resp.open} and closed at {resp.close}")
```
Result:
```
On: 2018-03-02 Apple opened at 43.2 and closed at 44.0525
```