### PR TITLE
Update README with more recent dates in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ def main():
     # RESTClient can be used as a context manager to facilitate closing the underlying http session
     # https://requests.readthedocs.io/en/master/user/advanced/#session-objects
     with RESTClient(key) as client:
-        resp = client.stocks_equities_daily_open_close("AAPL", "2018-03-02")
+        resp = client.stocks_equities_daily_open_close("AAPL", "2021-06-11")
         print(f"On: {resp.from_} Apple opened at {resp.open} and closed at {resp.close}")
 
 
@@ -93,8 +93,8 @@ def main():
     # RESTClient can be used as a context manager to facilitate closing the underlying http session
     # https://requests.readthedocs.io/en/master/user/advanced/#session-objects
     with RESTClient(key) as client:
-        from_ = "2019-01-01"
-        to = "2019-02-01"
+        from_ = "2021-01-01"
+        to = "2021-02-01"
         resp = client.stocks_equities_aggregates("AAPL", 1, "minute", from_, to, unadjusted=False)
 
         print(f"Minute aggregates for {resp.ticker} between {from_} and {to}.")


### PR DESCRIPTION
For free users, those of us just getting started with the client, the REST response 404s, because historical data back to 2018 is unavailable. A quick update of the docs prevents users who are just beginning with the client from receiving the following error:

```sh
python sample.py
Traceback (most recent call last):
  File "<PATH>/sample.py", line 14, in <module>
    main()
  File "<PATH>/sample.py", line 9, in main
    resp = client.stocks_equities_daily_open_close("AAPL", "2018-03-02")
  File "<PYTHON_PATH>/lib/python3.9/site-packages/polygon/rest/client.py", line 128, in stocks_equities_daily_open_close
    return self._handle_response("StocksEquitiesDailyOpenCloseApiResponse", endpoint, query_params)
  File "<PYTHON_PATH>/lib/python3.9/site-packages/polygon/rest/client.py", line 35, in _handle_response
    resp.raise_for_status()
  File "<PYTHON_PATH>/lib/python3.9/site-packages/requests/models.py", line 943, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://api.polygon.io/v1/open-close/AAPL/2018-03-02?apiKey=<REDACTED>
```