### PR TITLE
Add reference options contracts v3 endpoint

### DIFF
--- a/polygon/rest/client.py
+++ b/polygon/rest/client.py
@@ -37,7 +37,7 @@ class RESTClient:
     def reference_tickers(self, **query_params) -> models.ReferenceTickersApiResponse:
         endpoint = f"{self.url}/v2/reference/tickers"
         return self._handle_response("ReferenceTickersApiResponse", endpoint, query_params)
-    
+
     def reference_tickers_v3(self, next_url=None, **query_params) -> models.ReferenceTickersV3ApiResponse:
         endpoint = f"{self.url}/v3/reference/tickers" if not next_url else next_url
         return self._handle_response("ReferenceTickersV3ApiResponse", endpoint, query_params)
@@ -49,7 +49,7 @@ class RESTClient:
     def reference_ticker_details(self, symbol, **query_params) -> models.ReferenceTickerDetailsApiResponse:
         endpoint = f"{self.url}/v1/meta/symbols/{symbol}/company"
         return self._handle_response("ReferenceTickerDetailsApiResponse", endpoint, query_params)
-    
+
     def reference_ticker_details_vx(self, symbol, **query_params) -> models.ReferenceTickerDetailsV3ApiResponse:
         endpoint = f"{self.url}/vX/reference/tickers/{symbol}"
         return self._handle_response("ReferenceTickerDetailsV3ApiResponse", endpoint, query_params)
@@ -57,7 +57,7 @@ class RESTClient:
     def reference_ticker_news(self, symbol, **query_params) -> models.ReferenceTickerNewsApiResponse:
         endpoint = f"{self.url}/v1/meta/symbols/{symbol}/news"
         return self._handle_response("ReferenceTickerNewsApiResponse", endpoint, query_params)
-    
+
     def reference_ticker_news_v2(self, **query_params) -> models.ReferenceTickerNewsV2ApiResponse:
         endpoint = f"{self.url}/v2/reference/news"
         return self._handle_response("ReferenceTickerNewsV2ApiResponse", endpoint, query_params)
@@ -89,6 +89,10 @@ class RESTClient:
     def reference_market_holidays(self, **query_params) -> models.ReferenceMarketHolidaysApiResponse:
         endpoint = f"{self.url}/v1/marketstatus/upcoming"
         return self._handle_response("ReferenceMarketHolidaysApiResponse", endpoint, query_params)
+
+    def reference_options_contracts_v3(self, **query_params) -> models.ReferenceOptionsContractsV3ApiResponse:
+        endpoint = f"{self.url}/v3/reference/options/contracts"
+        return self._handle_response("ReferenceOptionsContractsV3ApiResponse", endpoint, query_params)
 
     def stocks_equities_exchanges(self, **query_params) -> models.StocksEquitiesExchangesApiResponse:
         endpoint = f"{self.url}/v1/meta/exchanges"
@@ -175,11 +179,11 @@ class RESTClient:
                                                         **query_params) -> models.ForexCurrenciesLastQuoteForACurrencyPairApiResponse:
         endpoint = f"{self.url}/v1/last_quote/currencies/{from_}/{to}"
         return self._handle_response("ForexCurrenciesLastQuoteForACurrencyPairApiResponse", endpoint, query_params)
-   
+
     def forex_currencies_grouped_daily(self, date, **query_params) -> models.ForexCurrenciesGroupedDailyApiResponse:
         endpoint = f"{self.url}/v2/aggs/grouped/locale/global/market/fx/{date}"
         return self._handle_response("ForexCurrenciesGroupedDailyApiResponse", endpoint, query_params)
-    
+
     def forex_currencies_previous_close(self, ticker, **query_params) -> models.ForexCurrenciesGroupedDailyApiResponse:
         endpoint = f"{self.url}/v2/aggs/ticker/{ticker}/prev"
         return self._handle_response("ForexCurrenciesPreviousCloseApiResponse", endpoint, query_params)
@@ -188,7 +192,7 @@ class RESTClient:
                                               **query_params) -> models.ForexCurrenciesSnapshotAllTickersApiResponse:
         endpoint = f"{self.url}/v2/snapshot/locale/global/markets/forex/tickers"
         return self._handle_response("ForexCurrenciesSnapshotAllTickersApiResponse", endpoint, query_params)
-    
+
     def forex_currencies_snapshot_single_ticker(self, ticker, **query_params) -> models.ForexCurrenciesSnapshotSingleTickerApiResponse:
         endpoint = f"{self.url}/v2/snapshot/locale/global/markets/forex/tickers/{ticker}"
         return self._handle_response("ForexCurrenciesSnapshotSingleTickerApiResponse", endpoint, query_params)
@@ -225,11 +229,11 @@ class RESTClient:
                                       **query_params) -> models.CryptoHistoricCryptoTradesApiResponse:
         endpoint = f"{self.url}/v1/historic/crypto/{from_}/{to}/{date}"
         return self._handle_response("CryptoHistoricCryptoTradesApiResponse", endpoint, query_params)
-    
+
     def crypto_grouped_daily(self, date, **query_params) -> models.CryptoGroupedDailyApiResponse:
         endpoint = f"{self.url}/v2/aggs/grouped/locale/global/market/crypto/{date}"
         return self._handle_response("CryptoGroupedDailyApiResponse", endpoint, query_params)
-    
+
     def crypto_previous_close(self, ticker, **query_params) -> models.CryptoPreviousCloseApiResponse:
         endpoint = f"{self.url}/v2/aggs/ticker/{ticker}/prev"
         return self._handle_response("CryptoPreviousCloseApiResponse", endpoint, query_params)

--- a/polygon/rest/models/__init__.py
+++ b/polygon/rest/models/__init__.py
@@ -49,6 +49,7 @@ from .definitions import StocksSnapshotAgg
 from .definitions import StocksSnapshotQuote
 from .definitions import Aggv2
 from .definitions import AggResponse
+from .definitions import OptionsContractV3
 from .definitions import ReferenceTickersApiResponse
 from .definitions import ReferenceTickersV3ApiResponse
 from .definitions import ReferenceTickerTypesApiResponse
@@ -63,6 +64,7 @@ from .definitions import ReferenceStockDividendsApiResponse
 from .definitions import ReferenceStockFinancialsApiResponse
 from .definitions import ReferenceMarketStatusApiResponse
 from .definitions import ReferenceMarketHolidaysApiResponse
+from .definitions import ReferenceOptionsContractsV3ApiResponse
 from .definitions import StocksEquitiesExchangesApiResponse
 from .definitions import StocksEquitiesHistoricTradesApiResponse
 from .definitions import HistoricTradesV2ApiResponse
@@ -101,7 +103,6 @@ from .definitions import StockSymbol
 from .definitions import ConditionTypeMap
 from .definitions import SymbolTypeMap
 from .definitions import TickerSymbol
-
 
 import typing
 
@@ -162,6 +163,7 @@ name_to_class: typing.Dict[str, typing.Callable[[], typing.Type[AnyDefinition]]]
     "StocksSnapshotQuote": StocksSnapshotQuote,
     "Aggv2": Aggv2,
     "AggResponse": AggResponse,
+    "OptionsContractV3": OptionsContractV3,
     "ReferenceTickersApiResponse": ReferenceTickersApiResponse,
     "ReferenceTickersV3ApiResponse": ReferenceTickersV3ApiResponse,
     "ReferenceTickerTypesApiResponse": ReferenceTickerTypesApiResponse,
@@ -176,6 +178,7 @@ name_to_class: typing.Dict[str, typing.Callable[[], typing.Type[AnyDefinition]]]
     "ReferenceStockFinancialsApiResponse": ReferenceStockFinancialsApiResponse,
     "ReferenceMarketStatusApiResponse": ReferenceMarketStatusApiResponse,
     "ReferenceMarketHolidaysApiResponse": ReferenceMarketHolidaysApiResponse,
+    "ReferenceOptionsContractsV3ApiResponse": ReferenceOptionsContractsV3ApiResponse,
     "StocksEquitiesExchangesApiResponse": StocksEquitiesExchangesApiResponse,
     "StocksEquitiesHistoricTradesApiResponse": StocksEquitiesHistoricTradesApiResponse,
     "HistoricTradesV2ApiResponse": HistoricTradesV2ApiResponse,
@@ -210,7 +213,6 @@ name_to_class: typing.Dict[str, typing.Callable[[], typing.Type[AnyDefinition]]]
     "CryptoSnapshotSingleTickerFullBookApiResponse": CryptoSnapshotSingleTickerFullBookApiResponse,
     "CryptoSnapshotGainersLosersApiResponse": CryptoSnapshotGainersLosersApiResponse,
     "CurrenciesAggregatesApiResponse": CurrenciesAggregatesApiResponse,
-
 }
 
 # noinspection SpellCheckingInspection

--- a/polygon/rest/models/__init__.py
+++ b/polygon/rest/models/__init__.py
@@ -49,6 +49,7 @@ from .definitions import StocksSnapshotAgg
 from .definitions import StocksSnapshotQuote
 from .definitions import Aggv2
 from .definitions import AggResponse
+from .definitions import OptionsContractAdditionalUnderlyingV3
 from .definitions import OptionsContractV3
 from .definitions import ReferenceTickersApiResponse
 from .definitions import ReferenceTickersV3ApiResponse
@@ -163,6 +164,7 @@ name_to_class: typing.Dict[str, typing.Callable[[], typing.Type[AnyDefinition]]]
     "StocksSnapshotQuote": StocksSnapshotQuote,
     "Aggv2": Aggv2,
     "AggResponse": AggResponse,
+    "OptionsContractAdditionalUnderlyingV3": OptionsContractAdditionalUnderlyingV3,
     "OptionsContractV3": OptionsContractV3,
     "ReferenceTickersApiResponse": ReferenceTickersApiResponse,
     "ReferenceTickersV3ApiResponse": ReferenceTickersV3ApiResponse,

--- a/polygon/rest/models/definitions.py
+++ b/polygon/rest/models/definitions.py
@@ -1,5 +1,5 @@
 import keyword
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 from polygon.rest import models
 
@@ -4175,8 +4175,35 @@ class CryptoSnapshotGainersLosersApiResponse(Definition):
 
 
 # noinspection SpellCheckingInspection
+class OptionsContractAdditionalUnderlyingV3(Definition):
+    _swagger_name_to_python = {
+        "amount": "amount",
+        "type": "type",
+        "underlying": "underlying",
+    }
+
+    _attribute_is_primitive = {
+        "amount": True,
+        "type": True,
+        "underlying": True,
+    }
+
+    _attributes_to_types = {
+        "amount": "float",
+        "type": "str",
+        "underlying": "str",
+    }
+
+    def __init__(self):
+        self.amount = float
+        self.type = str
+        self.underlying = str
+
+
+# noinspection SpellCheckingInspection
 class OptionsContractV3(Definition):
     _swagger_name_to_python = {
+        "additional_underlyings": "additional_underlyings",
         "cfi": "cfi",
         "contract_type": "contract_type",
         "correction": "correction",
@@ -4189,6 +4216,7 @@ class OptionsContractV3(Definition):
     }
 
     _attribute_is_primitive = {
+        "additional_underlyings": False,
         "cfi": True,
         "contract_type": True,
         "correction": True,
@@ -4202,6 +4230,7 @@ class OptionsContractV3(Definition):
     }
 
     _attributes_to_types = {
+        "additional_underlyings": "Optional[Array[OptionsContractAddtionalUnderlyingV3]]",
         "cfi": "str",
         "contract_type": "str",
         "correction": "int",
@@ -4214,6 +4243,7 @@ class OptionsContractV3(Definition):
     }
 
     def __init__(self):
+        self.additional_underlyings = Optional[Array[OptionsContractAddtionalUnderlyingV3]]
         self.cfi = str
         self.contract_type = str
         self.correction = int

--- a/polygon/rest/models/definitions.py
+++ b/polygon/rest/models/definitions.py
@@ -444,7 +444,7 @@ class CompanyV3(Definition):
     _attributes_is_primitive = {
         "ticker": True,
         "name": True,
-        "market": True, 
+        "market": True,
         "primary_exchange": True,
         "type": True,
         "active": True,
@@ -562,7 +562,7 @@ class SymbolV3(Definition):
     _attributes_is_primitive = {
         "ticker": True,
         "name": True,
-        "market": True, 
+        "market": True,
         "primary_exchange": True,
         "type": True,
         "active": True,
@@ -726,7 +726,7 @@ class Publisher(Definition):
         "favicon_url": "str",
     }
 
-    def __init__(self): 
+    def __init__(self):
         self.name: str
         self.logo_url: str
         self.homepage_url: str
@@ -4172,6 +4172,79 @@ class CryptoSnapshotGainersLosersApiResponse(Definition):
     def __init__(self):
         self.status: str
         self.tickers: List[CryptoSnapshotTicker]
+
+
+# noinspection SpellCheckingInspection
+class OptionsContractV3(Definition):
+    _swagger_name_to_python = {
+        "cfi": "cfi",
+        "contract_type": "contract_type",
+        "correction": "correction",
+        "exercise_style": "exercise_style",
+        "primary_exchange": "primary_exchange",
+        "shares_per_contract": "shares_per_contract",
+        "strike_price": "strike_price",
+        "ticker": "ticker",
+        "underlying_ticker": "underlying_ticker",
+    }
+
+    _attribute_is_primitive = {
+        "cfi": True,
+        "contract_type": True,
+        "correction": True,
+        "exercise_style": True,
+        "primary_exchange": True,
+        "shares_per_contract": True,
+        "strike_price": True,
+        "ticker": True,
+        "underlying_ticker": True,
+
+    }
+
+    _attributes_to_types = {
+        "cfi": "str",
+        "contract_type": "str",
+        "correction": "int",
+        "exercise_style": "str",
+        "primary_exchange": "str",
+        "shares_per_contract": "int",
+        "strike_price": "float",
+        "ticker": "str",
+        "underlying_ticker": "str",
+    }
+
+    def __init__(self):
+        self.cfi = str
+        self.contract_type = str
+        self.correction = int
+        self.exercise_style = str
+        self.primary_exchange = str
+        self.shares_per_contract = int
+        self.strike_price = float
+        self.ticker = str
+        self.underlying_ticker = str
+
+
+# noinspection SpellCheckingInspection
+class ReferenceOptionsContractsV3ApiResponse(Definition):
+    _swagger_name_to_python = {
+        "results": "results",
+        "status": "status",
+    }
+
+    _attribute_is_primitive = {
+        "results": False,
+        "status": True,
+    }
+
+    _attributes_to_types = {
+        "results": "List[OptionsContractV3]",
+        "status": "str",
+    }
+
+    def __init__(self):
+        self.results = List[OptionsContractV3]
+        self.status = str
 
 
 StockSymbol = str


### PR DESCRIPTION
Not sure if this is of any use to you all but I've added the [v3 reference options contracts endpoint](https://polygon.io/docs/options/get_v3_reference_options_contracts ) to RESTClient. 