### PR TITLE
Add a few options endpoints

### DIFF
--- a/polygon/rest/client.py
+++ b/polygon/rest/client.py
@@ -90,16 +90,16 @@ class RESTClient:
         endpoint = f"{self.url}/v1/marketstatus/upcoming"
         return self._handle_response("ReferenceMarketHolidaysApiResponse", endpoint, query_params)
 
-    def reference_options_contracts_v3(self, **query_params) -> models.ReferenceOptionsContractsV3ApiResponse:
-        endpoint = f"{self.url}/v3/reference/options/contracts"
+    def reference_options_contracts_v3(self, next_url=None, **query_params) -> models.ReferenceOptionsContractsV3ApiResponse:
+        endpoint = f"{self.url}/v3/reference/options/contracts" if not next_url else next_url
         return self._handle_response("ReferenceOptionsContractsV3ApiResponse", endpoint, query_params)
 
     def options_snapshot_v3(self, underlying_asset, option_contract, **query_params) -> models.OptionsSnapshotV3ApiResponse:
         endpoint = f"{self.url}/v3/snapshot/options/{underlying_asset}/{option_contract}"
         return self._handle_response("OptionsSnapshotV3ApiResponse", endpoint, query_params)
 
-    def options_quotes_v3(self, ticker, **query_params) -> models.OptionsQuotesV3ApiResponse:
-        endpoint = f"{self.url}/v3/quotes/{ticker}"
+    def options_quotes_v3(self, ticker, next_url=None, **query_params) -> models.OptionsQuotesV3ApiResponse:
+        endpoint = f"{self.url}/v3/quotes/{ticker}" if not next_url else next_url
         return self._handle_response("OptionsQuotesV3ApiResponse", endpoint, query_params)
 
     def stocks_equities_exchanges(self, **query_params) -> models.StocksEquitiesExchangesApiResponse:

--- a/polygon/rest/client.py
+++ b/polygon/rest/client.py
@@ -37,7 +37,7 @@ class RESTClient:
     def reference_tickers(self, **query_params) -> models.ReferenceTickersApiResponse:
         endpoint = f"{self.url}/v2/reference/tickers"
         return self._handle_response("ReferenceTickersApiResponse", endpoint, query_params)
-    
+
     def reference_tickers_v3(self, next_url=None, **query_params) -> models.ReferenceTickersV3ApiResponse:
         endpoint = f"{self.url}/v3/reference/tickers" if not next_url else next_url
         return self._handle_response("ReferenceTickersV3ApiResponse", endpoint, query_params)
@@ -49,7 +49,7 @@ class RESTClient:
     def reference_ticker_details(self, symbol, **query_params) -> models.ReferenceTickerDetailsApiResponse:
         endpoint = f"{self.url}/v1/meta/symbols/{symbol}/company"
         return self._handle_response("ReferenceTickerDetailsApiResponse", endpoint, query_params)
-    
+
     def reference_ticker_details_vx(self, symbol, **query_params) -> models.ReferenceTickerDetailsV3ApiResponse:
         endpoint = f"{self.url}/vX/reference/tickers/{symbol}"
         return self._handle_response("ReferenceTickerDetailsV3ApiResponse", endpoint, query_params)
@@ -57,7 +57,7 @@ class RESTClient:
     def reference_ticker_news(self, symbol, **query_params) -> models.ReferenceTickerNewsApiResponse:
         endpoint = f"{self.url}/v1/meta/symbols/{symbol}/news"
         return self._handle_response("ReferenceTickerNewsApiResponse", endpoint, query_params)
-    
+
     def reference_ticker_news_v2(self, **query_params) -> models.ReferenceTickerNewsV2ApiResponse:
         endpoint = f"{self.url}/v2/reference/news"
         return self._handle_response("ReferenceTickerNewsV2ApiResponse", endpoint, query_params)
@@ -89,6 +89,10 @@ class RESTClient:
     def reference_market_holidays(self, **query_params) -> models.ReferenceMarketHolidaysApiResponse:
         endpoint = f"{self.url}/v1/marketstatus/upcoming"
         return self._handle_response("ReferenceMarketHolidaysApiResponse", endpoint, query_params)
+
+    def reference_options_contracts_v3(self, **query_params) -> models.ReferenceOptionsContractsV3ApiResponse:
+        endpoint = f"{self.url}/v3/reference/options/contracts"
+        return self._handle_response("ReferenceOptionsContractsV3ApiResponse", endpoint, query_params)
 
     def stocks_equities_exchanges(self, **query_params) -> models.StocksEquitiesExchangesApiResponse:
         endpoint = f"{self.url}/v1/meta/exchanges"
@@ -175,11 +179,11 @@ class RESTClient:
                                                         **query_params) -> models.ForexCurrenciesLastQuoteForACurrencyPairApiResponse:
         endpoint = f"{self.url}/v1/last_quote/currencies/{from_}/{to}"
         return self._handle_response("ForexCurrenciesLastQuoteForACurrencyPairApiResponse", endpoint, query_params)
-   
+
     def forex_currencies_grouped_daily(self, date, **query_params) -> models.ForexCurrenciesGroupedDailyApiResponse:
         endpoint = f"{self.url}/v2/aggs/grouped/locale/global/market/fx/{date}"
         return self._handle_response("ForexCurrenciesGroupedDailyApiResponse", endpoint, query_params)
-    
+
     def forex_currencies_previous_close(self, ticker, **query_params) -> models.ForexCurrenciesGroupedDailyApiResponse:
         endpoint = f"{self.url}/v2/aggs/ticker/{ticker}/prev"
         return self._handle_response("ForexCurrenciesPreviousCloseApiResponse", endpoint, query_params)
@@ -188,7 +192,7 @@ class RESTClient:
                                               **query_params) -> models.ForexCurrenciesSnapshotAllTickersApiResponse:
         endpoint = f"{self.url}/v2/snapshot/locale/global/markets/forex/tickers"
         return self._handle_response("ForexCurrenciesSnapshotAllTickersApiResponse", endpoint, query_params)
-    
+
     def forex_currencies_snapshot_single_ticker(self, ticker, **query_params) -> models.ForexCurrenciesSnapshotSingleTickerApiResponse:
         endpoint = f"{self.url}/v2/snapshot/locale/global/markets/forex/tickers/{ticker}"
         return self._handle_response("ForexCurrenciesSnapshotSingleTickerApiResponse", endpoint, query_params)
@@ -225,11 +229,11 @@ class RESTClient:
                                       **query_params) -> models.CryptoHistoricCryptoTradesApiResponse:
         endpoint = f"{self.url}/v1/historic/crypto/{from_}/{to}/{date}"
         return self._handle_response("CryptoHistoricCryptoTradesApiResponse", endpoint, query_params)
-    
+
     def crypto_grouped_daily(self, date, **query_params) -> models.CryptoGroupedDailyApiResponse:
         endpoint = f"{self.url}/v2/aggs/grouped/locale/global/market/crypto/{date}"
         return self._handle_response("CryptoGroupedDailyApiResponse", endpoint, query_params)
-    
+
     def crypto_previous_close(self, ticker, **query_params) -> models.CryptoPreviousCloseApiResponse:
         endpoint = f"{self.url}/v2/aggs/ticker/{ticker}/prev"
         return self._handle_response("CryptoPreviousCloseApiResponse", endpoint, query_params)

--- a/polygon/rest/client.py
+++ b/polygon/rest/client.py
@@ -94,6 +94,14 @@ class RESTClient:
         endpoint = f"{self.url}/v3/reference/options/contracts"
         return self._handle_response("ReferenceOptionsContractsV3ApiResponse", endpoint, query_params)
 
+    def options_snapshot_v3(self, underlying_asset, option_contract, **query_params) -> models.OptionsSnapshotV3ApiResponse:
+        endpoint = f"{self.url}/v3/snapshot/options/{underlying_asset}/{option_contract}"
+        return self._handle_response("OptionsSnapshotV3ApiResponse", endpoint, query_params)
+
+    def options_quotes_v3(self, ticker, **query_params) -> models.OptionsQuotesV3ApiResponse:
+        endpoint = f"{self.url}/v3/quotes/{ticker}"
+        return self._handle_response("OptionsQuotesV3ApiResponse", endpoint, query_params)
+
     def stocks_equities_exchanges(self, **query_params) -> models.StocksEquitiesExchangesApiResponse:
         endpoint = f"{self.url}/v1/meta/exchanges"
         return self._handle_response("StocksEquitiesExchangesApiResponse", endpoint, query_params)

--- a/polygon/rest/models/__init__.py
+++ b/polygon/rest/models/__init__.py
@@ -49,6 +49,7 @@ from .definitions import StocksSnapshotAgg
 from .definitions import StocksSnapshotQuote
 from .definitions import Aggv2
 from .definitions import AggResponse
+from .definitions import OptionsContractV3
 from .definitions import ReferenceTickersApiResponse
 from .definitions import ReferenceTickersV3ApiResponse
 from .definitions import ReferenceTickerTypesApiResponse
@@ -63,6 +64,7 @@ from .definitions import ReferenceStockDividendsApiResponse
 from .definitions import ReferenceStockFinancialsApiResponse
 from .definitions import ReferenceMarketStatusApiResponse
 from .definitions import ReferenceMarketHolidaysApiResponse
+from .definitions import ReferenceOptionsContractsV3ApiResponse
 from .definitions import StocksEquitiesExchangesApiResponse
 from .definitions import StocksEquitiesHistoricTradesApiResponse
 from .definitions import HistoricTradesV2ApiResponse
@@ -101,7 +103,6 @@ from .definitions import StockSymbol
 from .definitions import ConditionTypeMap
 from .definitions import SymbolTypeMap
 from .definitions import TickerSymbol
-
 
 import typing
 
@@ -162,6 +163,7 @@ name_to_class: typing.Dict[str, typing.Callable[[], typing.Type[AnyDefinition]]]
     "StocksSnapshotQuote": StocksSnapshotQuote,
     "Aggv2": Aggv2,
     "AggResponse": AggResponse,
+    "OptionsContractV3": OptionsContractV3,
     "ReferenceTickersApiResponse": ReferenceTickersApiResponse,
     "ReferenceTickersV3ApiResponse": ReferenceTickersV3ApiResponse,
     "ReferenceTickerTypesApiResponse": ReferenceTickerTypesApiResponse,
@@ -176,6 +178,7 @@ name_to_class: typing.Dict[str, typing.Callable[[], typing.Type[AnyDefinition]]]
     "ReferenceStockFinancialsApiResponse": ReferenceStockFinancialsApiResponse,
     "ReferenceMarketStatusApiResponse": ReferenceMarketStatusApiResponse,
     "ReferenceMarketHolidaysApiResponse": ReferenceMarketHolidaysApiResponse,
+    "ReferenceOptionsContractsV3ApiResponse": ReferenceOptionsContractsV3ApiResponse,
     "StocksEquitiesExchangesApiResponse": StocksEquitiesExchangesApiResponse,
     "StocksEquitiesHistoricTradesApiResponse": StocksEquitiesHistoricTradesApiResponse,
     "HistoricTradesV2ApiResponse": HistoricTradesV2ApiResponse,
@@ -210,7 +213,6 @@ name_to_class: typing.Dict[str, typing.Callable[[], typing.Type[AnyDefinition]]]
     "CryptoSnapshotSingleTickerFullBookApiResponse": CryptoSnapshotSingleTickerFullBookApiResponse,
     "CryptoSnapshotGainersLosersApiResponse": CryptoSnapshotGainersLosersApiResponse,
     "CurrenciesAggregatesApiResponse": CurrenciesAggregatesApiResponse,
-
 }
 
 # noinspection SpellCheckingInspection

--- a/polygon/rest/models/__init__.py
+++ b/polygon/rest/models/__init__.py
@@ -100,6 +100,15 @@ from .definitions import CryptoSnapshotSingleTickerApiResponse
 from .definitions import CryptoSnapshotSingleTickerFullBookApiResponse
 from .definitions import CryptoSnapshotGainersLosersApiResponse
 from .definitions import CurrenciesAggregatesApiResponse
+from .definitions import OptionsQuoteV3
+from .definitions import OptionsQuotesV3ApiResponse
+from .definitions import OptionsSnapshotDayV3
+from .definitions import OptionsSnapshotDetailsV3
+from .definitions import OptionsGreeksV3
+from .definitions import OptionsSnapshotQuoteV3
+from .definitions import OptionsSnapshotUnderlyingAssetV3
+from .definitions import OptionsSnapshotV3
+from .definitions import OptionsSnapshotV3ApiResponse
 from .definitions import StockSymbol
 from .definitions import ConditionTypeMap
 from .definitions import SymbolTypeMap
@@ -215,6 +224,15 @@ name_to_class: typing.Dict[str, typing.Callable[[], typing.Type[AnyDefinition]]]
     "CryptoSnapshotSingleTickerFullBookApiResponse": CryptoSnapshotSingleTickerFullBookApiResponse,
     "CryptoSnapshotGainersLosersApiResponse": CryptoSnapshotGainersLosersApiResponse,
     "CurrenciesAggregatesApiResponse": CurrenciesAggregatesApiResponse,
+    "OptionsQuoteV3": OptionsQuoteV3,
+    "OptionsQuotesV3ApiResponse": OptionsQuotesV3ApiResponse,
+    "OptionsSnapshotDayV3": OptionsSnapshotDayV3,
+    "OptionsSnapshotDetailsV3": OptionsSnapshotDetailsV3,
+    "OptionsGreeksV3": OptionsGreeksV3,
+    "OptionsSnapshotQuoteV3": OptionsSnapshotQuoteV3,
+    "OptionsSnapshotUnderlyingAssetV3": OptionsSnapshotUnderlyingAssetV3,
+    "OptionsSnapshotV3": OptionsSnapshotV3,
+    "OptionsSnapshotV3ApiResponse": OptionsSnapshotV3ApiResponse,
 }
 
 # noinspection SpellCheckingInspection

--- a/polygon/rest/models/__init__.py
+++ b/polygon/rest/models/__init__.py
@@ -49,6 +49,7 @@ from .definitions import StocksSnapshotAgg
 from .definitions import StocksSnapshotQuote
 from .definitions import Aggv2
 from .definitions import AggResponse
+from .definitions import OptionsContractAdditionalUnderlyingV3
 from .definitions import OptionsContractV3
 from .definitions import ReferenceTickersApiResponse
 from .definitions import ReferenceTickersV3ApiResponse
@@ -163,6 +164,7 @@ name_to_class: typing.Dict[str, typing.Callable[[], typing.Type[AnyDefinition]]]
     "StocksSnapshotQuote": StocksSnapshotQuote,
     "Aggv2": Aggv2,
     "AggResponse": AggResponse,
+    "OptionsContractAdditionalUnderlyingV3": OptionsContractAdditionalUnderlyingV3,
     "OptionsContractV3": OptionsContractV3,
     "ReferenceTickersApiResponse": ReferenceTickersApiResponse,
     "ReferenceTickersV3ApiResponse": ReferenceTickersV3ApiResponse,

--- a/polygon/rest/models/definitions.py
+++ b/polygon/rest/models/definitions.py
@@ -1,5 +1,5 @@
 import keyword
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Optional
 
 from polygon.rest import models
 
@@ -4175,8 +4175,35 @@ class CryptoSnapshotGainersLosersApiResponse(Definition):
 
 
 # noinspection SpellCheckingInspection
+class OptionsContractAdditionalUnderlyingV3(Definition):
+    _swagger_name_to_python = {
+        "amount": "amount",
+        "type": "type",
+        "underlying": "underlying",
+    }
+
+    _attribute_is_primitive = {
+        "amount": True,
+        "type": True,
+        "underlying": True,
+    }
+
+    _attributes_to_types = {
+        "amount": "float",
+        "type": "str",
+        "underlying": "str",
+    }
+
+    def __init__(self):
+        self.amount = float
+        self.type = str
+        self.underlying = str
+
+
+# noinspection SpellCheckingInspection
 class OptionsContractV3(Definition):
     _swagger_name_to_python = {
+        "additional_underlyings": "additional_underlyings",
         "cfi": "cfi",
         "contract_type": "contract_type",
         "correction": "correction",
@@ -4189,6 +4216,7 @@ class OptionsContractV3(Definition):
     }
 
     _attribute_is_primitive = {
+        "additional_underlyings": False,
         "cfi": True,
         "contract_type": True,
         "correction": True,
@@ -4202,6 +4230,7 @@ class OptionsContractV3(Definition):
     }
 
     _attributes_to_types = {
+        "additional_underlyings": "Optional[Array[OptionsContractAddtionalUnderlyingV3]]",
         "cfi": "str",
         "contract_type": "str",
         "correction": "int",
@@ -4214,6 +4243,7 @@ class OptionsContractV3(Definition):
     }
 
     def __init__(self):
+        self.additional_underlyings = Optional[Array[OptionsContractAddtionalUnderlyingV3]]
         self.cfi = str
         self.contract_type = str
         self.correction = int

--- a/polygon/rest/models/definitions.py
+++ b/polygon/rest/models/definitions.py
@@ -444,7 +444,7 @@ class CompanyV3(Definition):
     _attributes_is_primitive = {
         "ticker": True,
         "name": True,
-        "market": True, 
+        "market": True,
         "primary_exchange": True,
         "type": True,
         "active": True,
@@ -562,7 +562,7 @@ class SymbolV3(Definition):
     _attributes_is_primitive = {
         "ticker": True,
         "name": True,
-        "market": True, 
+        "market": True,
         "primary_exchange": True,
         "type": True,
         "active": True,
@@ -726,7 +726,7 @@ class Publisher(Definition):
         "favicon_url": "str",
     }
 
-    def __init__(self): 
+    def __init__(self):
         self.name: str
         self.logo_url: str
         self.homepage_url: str
@@ -4172,6 +4172,79 @@ class CryptoSnapshotGainersLosersApiResponse(Definition):
     def __init__(self):
         self.status: str
         self.tickers: List[CryptoSnapshotTicker]
+
+
+# noinspection SpellCheckingInspection
+class OptionsContractV3(Definition):
+    _swagger_name_to_python = {
+        "cfi": "cfi",
+        "contract_type": "contract_type",
+        "correction": "correction",
+        "exercise_style": "exercise_style",
+        "primary_exchange": "primary_exchange",
+        "shares_per_contract": "shares_per_contract",
+        "strike_price": "strike_price",
+        "ticker": "ticker",
+        "underlying_ticker": "underlying_ticker",
+    }
+
+    _attribute_is_primitive = {
+        "cfi": True,
+        "contract_type": True,
+        "correction": True,
+        "exercise_style": True,
+        "primary_exchange": True,
+        "shares_per_contract": True,
+        "strike_price": True,
+        "ticker": True,
+        "underlying_ticker": True,
+
+    }
+
+    _attributes_to_types = {
+        "cfi": "str",
+        "contract_type": "str",
+        "correction": "int",
+        "exercise_style": "str",
+        "primary_exchange": "str",
+        "shares_per_contract": "int",
+        "strike_price": "float",
+        "ticker": "str",
+        "underlying_ticker": "str",
+    }
+
+    def __init__(self):
+        self.cfi = str
+        self.contract_type = str
+        self.correction = int
+        self.exercise_style = str
+        self.primary_exchange = str
+        self.shares_per_contract = int
+        self.strike_price = float
+        self.ticker = str
+        self.underlying_ticker = str
+
+
+# noinspection SpellCheckingInspection
+class ReferenceOptionsContractsV3ApiResponse(Definition):
+    _swagger_name_to_python = {
+        "results": "results",
+        "status": "status",
+    }
+
+    _attribute_is_primitive = {
+        "results": False,
+        "status": True,
+    }
+
+    _attributes_to_types = {
+        "results": "List[OptionsContractV3]",
+        "status": "str",
+    }
+
+    def __init__(self):
+        self.results = List[OptionsContractV3]
+        self.status = str
 
 
 StockSymbol = str

--- a/polygon/rest/models/definitions.py
+++ b/polygon/rest/models/definitions.py
@@ -1,5 +1,5 @@
 import keyword
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any
 
 from polygon.rest import models
 
@@ -4195,9 +4195,9 @@ class OptionsContractAdditionalUnderlyingV3(Definition):
     }
 
     def __init__(self):
-        self.amount = float
-        self.type = str
-        self.underlying = str
+        self.amount: float
+        self.type: str
+        self.underlying: str
 
 
 # noinspection SpellCheckingInspection
@@ -4230,7 +4230,7 @@ class OptionsContractV3(Definition):
     }
 
     _attributes_to_types = {
-        "additional_underlyings": "Optional[Array[OptionsContractAddtionalUnderlyingV3]]",
+        "additional_underlyings": "Array[OptionsContractAddtionalUnderlyingV3]",
         "cfi": "str",
         "contract_type": "str",
         "correction": "int",
@@ -4243,16 +4243,16 @@ class OptionsContractV3(Definition):
     }
 
     def __init__(self):
-        self.additional_underlyings = Optional[Array[OptionsContractAddtionalUnderlyingV3]]
-        self.cfi = str
-        self.contract_type = str
-        self.correction = int
-        self.exercise_style = str
-        self.primary_exchange = str
-        self.shares_per_contract = int
-        self.strike_price = float
-        self.ticker = str
-        self.underlying_ticker = str
+        self.additional_underlyings: Array[OptionsContractAddtionalUnderlyingV3]
+        self.cfi: str
+        self.contract_type: str
+        self.correction: int
+        self.exercise_style: str
+        self.primary_exchange: str
+        self.shares_per_contract: int
+        self.strike_price: float
+        self.ticker: str
+        self.underlying_ticker: str
 
 
 # noinspection SpellCheckingInspection
@@ -4314,14 +4314,14 @@ class OptionsQuoteV3(Definition):
     }
 
     def __init__(self):
-        self.ask_exchange = int
-        self.ask_price = float
-        self.ask_size = int
-        self.bid_exchange = int
-        self.bid_price = float
-        self.bid_size = int
-        self.sequence_number = int
-        self.sip_timestamp = int
+        self.ask_exchange: int
+        self.ask_price: float
+        self.ask_size: int
+        self.bid_exchange: int
+        self.bid_price: float
+        self.bid_size: int
+        self.sequence_number: int
+        self.sip_timestamp: int
 
 
 # noinspection SpellCheckingInspection
@@ -4342,8 +4342,8 @@ class OptionsQuotesV3ApiResponse(Definition):
     }
 
     def __init__(self):
-        self.results = List[OptionsQuoteV3]
-        self.status = str
+        self.results: List[OptionsQuoteV3]
+        self.status: str
 
 
 # noinspection SpellCheckingInspection
@@ -4388,16 +4388,16 @@ class OptionsSnapshotDayV3(Definition):
     }
 
     def __init__(self):
-        self.change = float
-        self.change_percent = float
-        self.close = float
-        self.high = float
-        self.last_updated = int
-        self.low = float
-        self.open = float
-        self.previous_close = float
-        self.volume = int
-        self.vwap = float
+        self.change: float
+        self.change_percent: float
+        self.close: float
+        self.high: float
+        self.last_updated: int
+        self.low: float
+        self.open: float
+        self.previous_close: float
+        self.volume: int
+        self.vwap: float
 
 
 # noinspection SpellCheckingInspection
@@ -4430,12 +4430,12 @@ class OptionsSnapshotDetailsV3(Definition):
     }
 
     def __init__(self):
-        self.contract_type = str
-        self.exercise_style = str
-        self.expiration_date = str
-        self.shares_per_contract = int
-        self.strike_price = float
-        self.ticker = str
+        self.contract_type: str
+        self.exercise_style: str
+        self.expiration_date: str
+        self.shares_per_contract: int
+        self.strike_price: float
+        self.ticker: str
 
 
 # noinspection SpellCheckingInspection
@@ -4462,10 +4462,10 @@ class OptionsGreeksV3(Definition):
     }
 
     def __init__(self):
-        self.delta = float
-        self.gamma = float
-        self.theta = float
-        self.vega = float
+        self.delta: float
+        self.gamma: float
+        self.theta: float
+        self.vega: float
 
 
 class OptionsSnapshotQuoteV3(Definition):
@@ -4500,13 +4500,13 @@ class OptionsSnapshotQuoteV3(Definition):
     }
 
     def __init__(self):
-        self.ask = float
-        self.ask_size = int
-        self.bid = float
-        self.bid_size = int
-        self.last_updated = int
-        self.midpoint = float
-        self.timeframe = str
+        self.ask: float
+        self.ask_size: int
+        self.bid: float
+        self.bid_size: int
+        self.last_updated: int
+        self.midpoint: float
+        self.timeframe: str
 
 
 # noinspection SpellCheckingInspection
@@ -4536,11 +4536,11 @@ class OptionsSnapshotUnderlyingAssetV3(Definition):
     }
 
     def __init__(self):
-        self.change_to_break_even = float
-        self.last_updated = int
-        self.price = float
-        self.ticker = str
-        self.timeframe = str
+        self.change_to_break_even: float
+        self.last_updated: int
+        self.price: float
+        self.ticker: str
+        self.timeframe: str
 
 
 # noinspection SpellCheckingInspection
@@ -4580,14 +4580,14 @@ class OptionsSnapshotV3(Definition):
     }
 
     def __init__(self):
-        self.break_even_price = float
-        self.day = OptionsSnapshotDayV3
-        self.details = OptionsSnapshotDetailsV3
-        self.greeks = OptionsGreeksV3
-        self.implied_volatility = float
-        self.last_quote = OptionsSnapshotQuoteV3
-        self.open_interest = int
-        self.underlying_asset = OptionsSnapshotUnderlyingAssetV3
+        self.break_even_price: float
+        self.day: OptionsSnapshotDayV3
+        self.details: OptionsSnapshotDetailsV3
+        self.greeks: OptionsGreeksV3
+        self.implied_volatility: float
+        self.last_quote: OptionsSnapshotQuoteV3
+        self.open_interest: int
+        self.underlying_asset: OptionsSnapshotUnderlyingAssetV3
 
 
 # noinspection SpellCheckingInspection
@@ -4608,8 +4608,8 @@ class OptionsSnapshotV3ApiResponse(Definition):
     }
 
     def __init__(self):
-        self.results = OptionsSnapshotV3
-        self.status = str
+        self.results: OptionsSnapshotV3
+        self.status: str
 
 
 StockSymbol = str

--- a/polygon/rest/models/definitions.py
+++ b/polygon/rest/models/definitions.py
@@ -4277,6 +4277,341 @@ class ReferenceOptionsContractsV3ApiResponse(Definition):
         self.status = str
 
 
+# noinspection SpellCheckingInspection
+class OptionsQuoteV3(Definition):
+    _swagger_name_to_python = {
+        "ask_exchange": "ask_exchange",
+        "ask_price": "ask_price",
+        "ask_size": "ask_size",
+        "bid_exchange": "bid_exchange",
+        "bid_price": "bid_price",
+        "bid_size": "bid_size",
+        "sequence_number": "sequence_number",
+        "sip_timestamp": "sip_timestamp",
+    }
+
+    _attribute_is_primitive = {
+        "ask_exchange": True,
+        "ask_price": True,
+        "ask_size": True,
+        "bid_exchange": True,
+        "bid_price": True,
+        "bid_size": True,
+        "sequence_number": True,
+        "sip_timestamp": True,
+
+    }
+
+    _attributes_to_types = {
+        "ask_exchange": "int",
+        "ask_price": "float",
+        "ask_size": "int",
+        "bid_exchange": "int",
+        "bid_price": "float",
+        "bid_size": "int",
+        "sequence_number": "int",
+        "sip_timestamp": "int",
+    }
+
+    def __init__(self):
+        self.ask_exchange = int
+        self.ask_price = float
+        self.ask_size = int
+        self.bid_exchange = int
+        self.bid_price = float
+        self.bid_size = int
+        self.sequence_number = int
+        self.sip_timestamp = int
+
+
+# noinspection SpellCheckingInspection
+class OptionsQuotesV3ApiResponse(Definition):
+    _swagger_name_to_python = {
+        "results": "results",
+        "status": "status",
+    }
+
+    _attribute_is_primitive = {
+        "results": False,
+        "status": True,
+    }
+
+    _attributes_to_types = {
+        "results": "List[OptionsQuoteV3]",
+        "status": "str",
+    }
+
+    def __init__(self):
+        self.results = List[OptionsQuoteV3]
+        self.status = str
+
+
+# noinspection SpellCheckingInspection
+class OptionsSnapshotDayV3(Definition):
+    _swagger_name_to_python = {
+        "change": "change",
+        "change_percent": "change_percent",
+        "close": "close",
+        "high": "high",
+        "last_updated": "last_updated",
+        "low": "low",
+        "open": "open",
+        "previous_close": "previous_close",
+        "volume": "volume",
+        "vwap": "vwap",
+    }
+
+    _attribute_is_primitive = {
+        "change": True,
+        "change_percent": True,
+        "close": True,
+        "high": True,
+        "last_updated": True,
+        "low": True,
+        "open": True,
+        "previous_close": True,
+        "volume": True,
+        "vwap": True,
+    }
+
+    _attributes_to_types = {
+        "change": "float",
+        "change_percent": "float",
+        "close": "float",
+        "high": "float",
+        "last_updated": "int",
+        "low": "float",
+        "open": "float",
+        "previous_close": "float",
+        "volume": "int",
+        "vwap": "float",
+    }
+
+    def __init__(self):
+        self.change = float
+        self.change_percent = float
+        self.close = float
+        self.high = float
+        self.last_updated = int
+        self.low = float
+        self.open = float
+        self.previous_close = float
+        self.volume = int
+        self.vwap = float
+
+
+# noinspection SpellCheckingInspection
+class OptionsSnapshotDetailsV3(Definition):
+    _swagger_name_to_python = {
+        "contract_type": "contract_type",
+        "exercise_style": "exercise_style",
+        "expiration_date": "expiration_date",
+        "shares_per_contract": "shares_per_contract",
+        "strike_price": "strike_price",
+        "ticker": "ticker",
+    }
+
+    _attribute_is_primitive = {
+        "contract_type": True,
+        "exercise_style": True,
+        "expiration_date": True,
+        "shares_per_contract": True,
+        "strike_price": True,
+        "ticker": True,
+    }
+
+    _attributes_to_types = {
+        "contract_type": "str",
+        "exercise_style": "str",
+        "expiration_date": "str",
+        "shares_per_contract": "int",
+        "strike_price": "float",
+        "ticker": "str",
+    }
+
+    def __init__(self):
+        self.contract_type = str
+        self.exercise_style = str
+        self.expiration_date = str
+        self.shares_per_contract = int
+        self.strike_price = float
+        self.ticker = str
+
+
+# noinspection SpellCheckingInspection
+class OptionsGreeksV3(Definition):
+    _swagger_name_to_python = {
+        "delta": "delta",
+        "gamma": "gamma",
+        "theta": "theta",
+        "vega": "vega",
+    }
+
+    _attribute_is_primitive = {
+        "delta": True,
+        "gamma": True,
+        "theta": True,
+        "vega": True,
+    }
+
+    _attributes_to_types = {
+        "delta": "float",
+        "gamma": "float",
+        "theta": "float",
+        "vega": "float",
+    }
+
+    def __init__(self):
+        self.delta = float
+        self.gamma = float
+        self.theta = float
+        self.vega = float
+
+
+class OptionsSnapshotQuoteV3(Definition):
+    _swagger_name_to_python = {
+        "ask": "ask",
+        "ask_size": "ask_size",
+        "bid": "bid",
+        "bid_size": "bid_size",
+        "last_updated": "last_updated",
+        "midpoint": "midpoint",
+        "timeframe": "timeframe",
+    }
+
+    _attribute_is_primitive = {
+        "ask": True,
+        "ask_size": True,
+        "bid": True,
+        "bid_size": True,
+        "last_updated": True,
+        "midpoint": True,
+        "timeframe": True,
+    }
+
+    _attributes_to_types = {
+        "ask": "float",
+        "ask_size": "int",
+        "bid": "float",
+        "bid_size": "int",
+        "last_updated": "int",
+        "midpoint": "float",
+        "timeframe": "str",
+    }
+
+    def __init__(self):
+        self.ask = float
+        self.ask_size = int
+        self.bid = float
+        self.bid_size = int
+        self.last_updated = int
+        self.midpoint = float
+        self.timeframe = str
+
+
+# noinspection SpellCheckingInspection
+class OptionsSnapshotUnderlyingAssetV3(Definition):
+    _swagger_name_to_python = {
+        "change_to_break_even": "change_to_break_even",
+        "last_updated": "last_updated",
+        "price": "price",
+        "ticker": "ticker",
+        "timeframe": "timeframe",
+    }
+
+    _attribute_is_primitive = {
+        "change_to_break_even": True,
+        "last_updated": True,
+        "price": True,
+        "ticker": True,
+        "timeframe": True,
+    }
+
+    _attributes_to_types = {
+        "change_to_break_even": "float",
+        "last_updated": "int",
+        "price": "float",
+        "ticker": "str",
+        "timeframe": "str",
+    }
+
+    def __init__(self):
+        self.change_to_break_even = float
+        self.last_updated = int
+        self.price = float
+        self.ticker = str
+        self.timeframe = str
+
+
+# noinspection SpellCheckingInspection
+class OptionsSnapshotV3(Definition):
+    _swagger_name_to_python = {
+        "break_even_price": "break_even_price",
+        "day": "day",
+        "details": "details",
+        "greeks": "greeks",
+        "implied_volatility": "implied_volatility",
+        "last_quote": "last_quote",
+        "open_interest": "open_interest",
+        "underlying_asset": "underlying_asset",
+    }
+
+    _attribute_is_primitive = {
+        "break_even_price": True,
+        "day": False,
+        "details": False,
+        "greeks": False,
+        "implied_volatility": True,
+        "last_quote": False,
+        "open_interest": True,
+        "underlying_asset": False,
+    }
+
+    _attributes_to_types = {
+        "break_even_price": "float",
+        "day": "OptionsSnapshotDayV3",
+        "details": "OptionsSnapshotDetailsV3",
+        "greeks": "OptionsGreeksV3",
+        "implied_volatility": "float",
+        "last_quote": "OptionsSnapshotQuoteV3",
+        "open_interest": "int",
+        "underlying_asset": "OptionsSnapshotUnderlyingAssetV3",
+
+    }
+
+    def __init__(self):
+        self.break_even_price = float
+        self.day = OptionsSnapshotDayV3
+        self.details = OptionsSnapshotDetailsV3
+        self.greeks = OptionsGreeksV3
+        self.implied_volatility = float
+        self.last_quote = OptionsSnapshotQuoteV3
+        self.open_interest = int
+        self.underlying_asset = OptionsSnapshotUnderlyingAssetV3
+
+
+# noinspection SpellCheckingInspection
+class OptionsSnapshotV3ApiResponse(Definition):
+    _swagger_name_to_python = {
+        "results": "results",
+        "status": "status",
+    }
+
+    _attribute_is_primitive = {
+        "results": False,
+        "status": True,
+    }
+
+    _attributes_to_types = {
+        "results": "OptionsSnapshotV3",
+        "status": "str",
+    }
+
+    def __init__(self):
+        self.results = OptionsSnapshotV3
+        self.status = str
+
+
 StockSymbol = str
 ConditionTypeMap = Dict[str, str]
 SymbolTypeMap = Dict[str, str]

--- a/polygon/rest/models/definitions.py
+++ b/polygon/rest/models/definitions.py
@@ -4260,21 +4260,29 @@ class ReferenceOptionsContractsV3ApiResponse(Definition):
     _swagger_name_to_python = {
         "results": "results",
         "status": "status",
+        "next_url": "next_url",
+        "request_id": "request_id",
     }
 
     _attribute_is_primitive = {
         "results": False,
         "status": True,
+        "next_url": True,
+        "request_id": True,
     }
 
     _attributes_to_types = {
         "results": "List[OptionsContractV3]",
         "status": "str",
+        "next_url": "str",
+        "request_id": "str",
     }
 
     def __init__(self):
-        self.results = List[OptionsContractV3]
-        self.status = str
+        self.results: List[OptionsContractV3]
+        self.status: str
+        self.next_url: str
+        self.request_id: str
 
 
 # noinspection SpellCheckingInspection
@@ -4329,21 +4337,25 @@ class OptionsQuotesV3ApiResponse(Definition):
     _swagger_name_to_python = {
         "results": "results",
         "status": "status",
+        "next_url": "next_url",
     }
 
     _attribute_is_primitive = {
         "results": False,
         "status": True,
+        "next_url": True,
     }
 
     _attributes_to_types = {
         "results": "List[OptionsQuoteV3]",
         "status": "str",
+        "next_url": "str",
     }
 
     def __init__(self):
         self.results: List[OptionsQuoteV3]
         self.status: str
+        self.next_url: str
 
 
 # noinspection SpellCheckingInspection
@@ -4595,21 +4607,29 @@ class OptionsSnapshotV3ApiResponse(Definition):
     _swagger_name_to_python = {
         "results": "results",
         "status": "status",
+        "next_url": "next_url",
+        "request_id": "request_id",
     }
 
     _attribute_is_primitive = {
         "results": False,
         "status": True,
+        "next_url": True,
+        "request_id": True,
     }
 
     _attributes_to_types = {
         "results": "OptionsSnapshotV3",
         "status": "str",
+        "next_url": "str",
+        "request_id": "str",
     }
 
     def __init__(self):
         self.results: OptionsSnapshotV3
         self.status: str
+        self.next_url: str
+        self.request_id: str
 
 
 StockSymbol = str


### PR DESCRIPTION
Not sure if this is helpful for you all but I added a couple of options endpoints that I needed:
 * https://polygon.io/docs/options/get_v3_quotes__optionsticker
 * https://polygon.io/docs/options/get_v3_snapshot_options__underlyingasset___optioncontract
 * https://polygon.io/docs/options/get_v3_reference_options_contracts
 
I wasn't quite sure of the naming conventions or how these ought to be organized so I'm happy to switch that around for you if this is an otherwise useful PR.