### PR TITLE
Update websocket_client.py

### DIFF
--- a/polygon/websocket/websocket_client.py
+++ b/polygon/websocket/websocket_client.py
@@ -1,4 +1,3 @@
-import signal
 import threading
 from typing import Optional, Callable
 
@@ -36,12 +35,6 @@ class WebSocketClient:
         # self._run_thread is only set if the client is run asynchronously
         self._run_thread: Optional[threading.Thread] = None
 
-        # TODO: this probably isn't great design.
-        #  If the user defines their own signal handler then this will gets overwritten.
-        #  We still need to make sure that killing, terminating, interrupting the program closes the connection
-        signal.signal(signal.SIGINT, self._cleanup_signal_handler())
-        signal.signal(signal.SIGTERM, self._cleanup_signal_handler())
-
     def run(self):
         self.ws.run_forever()
 
@@ -67,9 +60,6 @@ class WebSocketClient:
 
         sub_message = '{"action":"unsubscribe","params":"%s"}' % self._format_params(params)
         self.ws.send(sub_message)
-
-    def _cleanup_signal_handler(self):
-        return lambda signalnum, frame: self.close_connection()
 
     def _authenticate(self, ws):
         ws.send('{"action":"auth","params":"%s"}' % self.auth_key)


### PR DESCRIPTION
There should be no need to install the signal handlers to close the connection if the application terminates.
If it does, the OS will close all the file handles owned by the terminating process, among which the sockets used by the connection.
And upon closure, the TCP stack will properly issue a reset which will be noticed by the remote server.

The issue is that, on top of what already underlined in the existing comments (override of user specified signals), setting a signal handler from outside the main thread will result with an error:

```
ER20220322 17:42:45.726997;root;utils:   File "/usr/local/lib/python3.8/dist-packages/polygon/websocket/websocket_client.py", line 42, in __init__
ER20220322 17:42:45.726997;root;utils:     signal.signal(signal.SIGINT, self._cleanup_signal_handler())
ER20220322 17:42:45.726997;root;utils:   File "/usr/lib/python3.8/signal.py", line 47, in signal
ER20220322 17:42:45.726997;root;utils:     handler = _signal.signal(_enum_to_int(signalnum), _enum_to_int(handler))
ER20220322 17:42:45.726997;root;utils: ValueError: signal only works in main thread
```

This in turn leads to the inability to create a websocket connection from outside the main thread.