### PR TITLE
Fix missing param in get_ticker_details

### DIFF
--- a/polygon/rest/reference.py
+++ b/polygon/rest/reference.py
@@ -135,7 +135,11 @@ class TickersClient(BaseClient):
         url = f"/v3/reference/tickers/{ticker}"
 
         return self._get(
-            path=url, params=params, deserializer=TickerDetails.from_dict, raw=raw
+            path=url,
+            params=params,
+            deserializer=TickerDetails.from_dict,
+            raw=raw,
+            result_key="results",
         )
 
     def list_ticker_news(


### PR DESCRIPTION
Missing `result_key` in `get_ticker_details` had me scratching my head for longer than I'd like to admit as it kept returning None's 🤣

![image](https://user-images.githubusercontent.com/61340027/167342605-733dfc07-66d1-4b1c-ada6-319b458321f4.png)

![image](https://user-images.githubusercontent.com/61340027/167342688-4c89a607-5455-43b3-8683-c956cb471b36.png)

