### PR TITLE
Add Logger

### DIFF
--- a/polygon/logging.py
+++ b/polygon/logging.py
@@ -1,0 +1,12 @@
+import logging
+import sys
+
+
+def get_logger(name: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter('%(asctime)s %(name)s %(levelname)s %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+    return logger

--- a/polygon/logging.py
+++ b/polygon/logging.py
@@ -5,7 +5,7 @@ import sys
 def get_logger(name: str) -> logging.Logger:
     logger = logging.getLogger(name)
     handler = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter('%(asctime)s %(name)s %(levelname)s %(message)s')
+    formatter = logging.Formatter("%(asctime)s %(name)s %(levelname)s: %(message)s")
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 

--- a/polygon/rest/base.py
+++ b/polygon/rest/base.py
@@ -6,9 +6,10 @@ from enum import Enum
 from typing import Optional, Any, Dict
 from datetime import datetime
 import pkg_resources  # part of setuptools
+from ..logging import get_logger
 import logging
-import sys
 
+logger = get_logger("RESTClient")
 version = "unknown"
 try:
     version = pkg_resources.require("polygon-api-client")[0].version
@@ -19,8 +20,6 @@ except:
 class NoResultsError(Exception):
     pass
 
-logger = logging.getLogger('RESTClient')
-logger.addHandler(logging.StreamHandler(sys.stdout))
 
 class BaseClient:
     def __init__(

--- a/polygon/rest/base.py
+++ b/polygon/rest/base.py
@@ -6,6 +6,8 @@ from enum import Enum
 from typing import Optional, Any, Dict
 from datetime import datetime
 import pkg_resources  # part of setuptools
+import logging
+import sys
 
 version = "unknown"
 try:
@@ -17,6 +19,8 @@ except:
 class NoResultsError(Exception):
     pass
 
+logger = logging.getLogger('RESTClient')
+logger.addHandler(logging.StreamHandler(sys.stdout))
 
 class BaseClient:
     def __init__(
@@ -49,7 +53,8 @@ class BaseClient:
         )
         self.timeout = urllib3.Timeout(connect=connect_timeout, read=read_timeout)
         self.retries = retries
-        self.verbose = verbose
+        if verbose:
+            logger.setLevel(logging.DEBUG)
 
     def _decode(self, resp):
         return json.loads(resp.data.decode("utf-8"))
@@ -65,8 +70,7 @@ class BaseClient:
         if params is None:
             params = {}
         params = {str(k): str(v) for k, v in params.items() if v is not None}
-        if self.verbose:
-            print("_get", path, params)
+        logger.debug("_get %s params %s", path, params)
         resp = self.client.request(
             "GET",
             self.BASE + path,
@@ -144,7 +148,6 @@ class BaseClient:
         self,
         path: str,
         params: dict,
-        raw: bool,
         deserializer,
         result_key: str = "results",
     ):
@@ -183,5 +186,4 @@ class BaseClient:
             params=params,
             deserializer=deserializer,
             result_key=result_key,
-            raw=True,
         )

--- a/polygon/websocket/__init__.py
+++ b/polygon/websocket/__init__.py
@@ -1,5 +1,4 @@
 import os
-import sys
 from enum import Enum
 from typing import Optional, Union, List, Set, Callable, Awaitable
 import logging
@@ -10,16 +9,16 @@ import certifi
 from .models import *
 from websockets.client import connect, WebSocketClientProtocol
 from websockets.exceptions import ConnectionClosedOK, ConnectionClosedError
+from ..logging import get_logger
+import logging
 
 env_key = "POLYGON_API_KEY"
+logger = get_logger("WebSocketClient")
 
 
 class AuthError(Exception):
     pass
 
-
-logger = logging.getLogger('WebSocketClient')
-logger.addHandler(logging.StreamHandler(sys.stdout))
 
 class WebSocketClient:
     def __init__(

--- a/polygon/websocket/__init__.py
+++ b/polygon/websocket/__init__.py
@@ -110,7 +110,9 @@ class WebSocketClient:
                     raise AuthError(auth_msg_parsed[0]["message"])
                 while True:
                     if self.schedule_resub:
-                        logger.debug("reconciling: %s %s", self.subs, self.scheduled_subs)
+                        logger.debug(
+                            "reconciling: %s %s", self.subs, self.scheduled_subs
+                        )
                         new_subs = self.scheduled_subs.difference(self.subs)
                         await self._subscribe(new_subs)
                         old_subs = self.subs.difference(self.scheduled_subs)
@@ -184,7 +186,7 @@ class WebSocketClient:
         s = s.strip()
         split = s.split(".")
         if len(split) != 2:
-            WebSocketClient.logger.warning("invalid subscription:", s)
+            logger.warning("invalid subscription:", s)
             return [None, None]
 
         return split

--- a/polygon/websocket/models/__init__.py
+++ b/polygon/websocket/models/__init__.py
@@ -1,6 +1,7 @@
 from typing import Dict, Any, List
 from .common import *
 from .models import *
+import logging
 
 
 def parse_single(data: Dict[str, Any]):
@@ -30,13 +31,13 @@ def parse_single(data: Dict[str, Any]):
     return None
 
 
-def parse(msg: List[Dict[str, Any]]) -> List[WebSocketMessage]:
+def parse(msg: List[Dict[str, Any]], logger: logging.Logger) -> List[WebSocketMessage]:
     res = []
     for m in msg:
         parsed = parse_single(m)
         if parsed is None:
             if m["ev"] != "status":
-                print("could not parse message", m)
+                logger.warning("could not parse message %s", m)
         else:
             res.append(parsed)
     return res

--- a/test_websocket/base_ws.py
+++ b/test_websocket/base_ws.py
@@ -22,4 +22,7 @@ class BaseTest(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         self.maxDiff = None
         loop = asyncio.get_event_loop()
-        loop.create_task(run_mock_server())
+        self.task = loop.create_task(run_mock_server())
+
+    async def asyncTearDown(self):
+        self.task.cancel()


### PR DESCRIPTION
Make logs more extensible. Keep existing api of `verbose`. Logger can still be overridden by consumers via `logging.getLogger('RESTClient')` or `logging.getLogger('WebsocketClient')`.

Logs look like this now:
```
2022-05-17 15:27:17,493 RESTClient DEBUG: _get /v2/aggs/ticker/AAPL/range/1/day/2022-04-04/2022-04-04 params {}
2022-05-17 15:29:30,465 WebSocketClient DEBUG: sub desired: T.AAPL
2022-05-17 15:29:30,466 WebSocketClient DEBUG: sub desired: T.AMZN
2022-05-17 15:29:30,466 WebSocketClient DEBUG: sub desired: T.*
2022-05-17 15:29:30,466 WebSocketClient DEBUG: sub undesired: T.*
2022-05-17 15:29:30,466 WebSocketClient DEBUG: closing
2022-05-17 15:29:30,466 WebSocketClient WARNING: no websocket open to close
```