### PR TITLE
add market type for grouped endpoint

### DIFF
--- a/polygon/rest/aggs.py
+++ b/polygon/rest/aggs.py
@@ -53,10 +53,10 @@ class AggsClient(BaseClient):
     def get_grouped_daily_aggs(
         self,
         date: str,
-        market_type: str = "stocks",
         adjusted: Optional[bool] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        market_type: str = "stocks",
     ) -> Union[GroupedDailyAgg, HTTPResponse]:
         """
         Get the daily open, high, low, and close (OHLC) for the entire market.

--- a/polygon/rest/aggs.py
+++ b/polygon/rest/aggs.py
@@ -53,6 +53,7 @@ class AggsClient(BaseClient):
     def get_grouped_daily_aggs(
         self,
         date: str,
+        market_type: str = "stocks",
         adjusted: Optional[bool] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
@@ -66,7 +67,7 @@ class AggsClient(BaseClient):
         :param raw: Return raw object instead of results object
         :return: List of grouped daily aggregates
         """
-        url = f"/v2/aggs/grouped/locale/us/market/stocks/{date}"
+        url = f"/v2/aggs/grouped/locale/us/market/{market_type}/{date}"
 
         return self._get(
             path=url,

--- a/polygon/rest/aggs.py
+++ b/polygon/rest/aggs.py
@@ -50,6 +50,8 @@ class AggsClient(BaseClient):
             raw=raw,
         )
 
+    # TODO: next breaking change release move "market_type" to be 2nd mandatory
+    # param
     def get_grouped_daily_aggs(
         self,
         date: str,


### PR DESCRIPTION
This will be inconsistent with other APIs that take a required market type parameter in the order of the URL... but oh well