### PR TITLE
fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @clickingbuttons
-* @Darcy-Linde
+* @clickingbuttons @Darcy-Linde


### PR DESCRIPTION
i think all global codeowners need to be on a single line which is why only @Darcy-Linde is automatically assigned at the moment. see the docs for more details: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners