### PR TITLE
include date param in get_ticker_details

### DIFF
--- a/polygon/rest/reference.py
+++ b/polygon/rest/reference.py
@@ -137,7 +137,7 @@ class TickersClient(BaseClient):
 
         return self._get(
             path=url,
-            params=params,
+            params=self._get_params(self.get_ticker_details, locals()),
             deserializer=TickerDetails.from_dict,
             raw=raw,
             result_key="results",

--- a/test_rest/mocks/v3/reference/tickers/AAPL&date=2020-10-01.json
+++ b/test_rest/mocks/v3/reference/tickers/AAPL&date=2020-10-01.json
@@ -1,0 +1,38 @@
+{
+ "results": {
+  "ticker": "AAPL",
+  "name": "Apple Inc.",
+  "market": "stocks",
+  "locale": "us",
+  "primary_exchange": "XNAS",
+  "type": "CS",
+  "active": true,
+  "currency_name": "usd",
+  "cik": "0000320193",
+  "composite_figi": "BBG000B9XRY4",
+  "share_class_figi": "BBG001S5N8V8",
+  "market_cap": 1916103105630,
+  "phone_number": "(408) 996-1010",
+  "address": {
+   "address1": "ONE APPLE PARK WAY",
+   "city": "CUPERTINO",
+   "state": "CA",
+   "postal_code": "95014"
+  },
+  "description": "Apple designs a wide variety of consumer electronic devices, including smartphones (iPhone), tablets (iPad), PCs (Mac), smartwatches (Apple Watch), AirPods, and TV boxes (Apple TV), among others. The iPhone makes up the majority of Apple's total revenue. In addition, Apple offers its customers a variety of services such as Apple Music, iCloud, Apple Care, Apple TV+, Apple Arcade, Apple Card, and Apple Pay, among others. Apple's products run internally developed software and semiconductors, and the firm is well known for its integration of hardware, software and services. Apple's products are distributed online as well as through company-owned stores and third-party retailers. The company generates roughly 40% of its revenue from the Americas, with the remainder earned internationally.",
+  "sic_code": "3571",
+  "sic_description": "ELECTRONIC COMPUTERS",
+  "ticker_root": "AAPL",
+  "homepage_url": "https://www.apple.com",
+  "total_employees": 154000,
+  "list_date": "1980-12-12",
+  "branding": {
+   "logo_url": "https://api.polygon.io/v1/reference/company-branding/d3d3LmFwcGxlLmNvbQ/images/2022-05-01_logo.svg",
+   "icon_url": "https://api.polygon.io/v1/reference/company-branding/d3d3LmFwcGxlLmNvbQ/images/2022-05-01_icon.png"
+  },
+  "share_class_shares_outstanding": 16319440000,
+  "weighted_shares_outstanding": 16185181000
+ },
+ "status": "OK",
+ "request_id": "ce8688b5f3a571351376ebd77acd146e"
+}

--- a/test_rest/test_tickers.py
+++ b/test_rest/test_tickers.py
@@ -128,6 +128,11 @@ class TickersTest(BaseTest):
         )
         self.assertEqual(details, expected)
 
+        expected.market_cap = 1916103105630
+        details = self.c.get_ticker_details("AAPL", date="2020-10-01")
+
+        self.assertEqual(details, expected)
+
     def test_list_ticker_news(self):
         news = [t for t in self.c.list_ticker_news("NFLX")]
         expected = [


### PR DESCRIPTION
Fixes #320 

I put a second assert in the same test method, but happy to factor the expected response data out and create a second test method, if you prefer to follow the "one assertion per test" paradigm