### PR TITLE
Added options parameter to rest api functions.

### DIFF
--- a/polygon/rest/aggs.py
+++ b/polygon/rest/aggs.py
@@ -19,6 +19,7 @@ class AggsClient(BaseClient):
         limit: Optional[int] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[List[Agg], HTTPResponse]:
         """
         Get aggregate bars for a ticker over a given date range in custom time window sizes.
@@ -48,6 +49,7 @@ class AggsClient(BaseClient):
             result_key="results",
             deserializer=Agg.from_dict,
             raw=raw,
+            options=options,
         )
 
     # TODO: next breaking change release move "market_type" to be 2nd mandatory
@@ -60,6 +62,7 @@ class AggsClient(BaseClient):
         raw: bool = False,
         market_type: str = "stocks",
         include_otc: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[GroupedDailyAgg, HTTPResponse]:
         """
         Get the daily open, high, low, and close (OHLC) for the entire market.
@@ -78,6 +81,7 @@ class AggsClient(BaseClient):
             result_key="results",
             deserializer=GroupedDailyAgg.from_dict,
             raw=raw,
+            options=options,
         )
 
     def get_daily_open_close_agg(
@@ -87,6 +91,7 @@ class AggsClient(BaseClient):
         adjusted: Optional[bool] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[DailyOpenCloseAgg, HTTPResponse]:
         """
         Get the open, close and afterhours prices of a stock symbol on a certain date.
@@ -105,6 +110,7 @@ class AggsClient(BaseClient):
             params=self._get_params(self.get_daily_open_close_agg, locals()),
             deserializer=DailyOpenCloseAgg.from_dict,
             raw=raw,
+            options=options,
         )
 
     def get_previous_close_agg(
@@ -113,6 +119,7 @@ class AggsClient(BaseClient):
         adjusted: Optional[bool] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[PreviousCloseAgg, HTTPResponse]:
         """
         Get the previous day's open, high, low, and close (OHLC) for the specified stock ticker.
@@ -131,4 +138,5 @@ class AggsClient(BaseClient):
             result_key="results",
             deserializer=PreviousCloseAgg.from_dict,
             raw=raw,
+            options=options,
         )

--- a/polygon/rest/base.py
+++ b/polygon/rest/base.py
@@ -67,11 +67,15 @@ class BaseClient:
         result_key: Optional[str] = None,
         deserializer=None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Any:
         if params is None:
             params = {}
         params = {str(k): str(v) for k, v in params.items() if v is not None}
         logger.debug("_get %s params %s", path, params)
+
+        # Todo: Handle Options
+
         resp = self.client.request(
             "GET",
             self.BASE + path,
@@ -153,6 +157,7 @@ class BaseClient:
         params: dict,
         deserializer,
         result_key: str = "results",
+        options: Optional[dict] = None,
     ):
         while True:
             resp = self._get(
@@ -161,6 +166,7 @@ class BaseClient:
                 deserializer=deserializer,
                 result_key=result_key,
                 raw=True,
+                options=options,
             )
             decoded = self._decode(resp)
             for t in decoded[result_key]:
@@ -178,10 +184,15 @@ class BaseClient:
         raw: bool,
         deserializer,
         result_key: str = "results",
+        options: Optional[dict] = None,
     ):
         if raw:
             return self._get(
-                path=path, params=params, deserializer=deserializer, raw=True
+                path=path,
+                params=params,
+                deserializer=deserializer,
+                raw=True,
+                options=options,
             )
 
         return self._paginate_iter(
@@ -189,4 +200,5 @@ class BaseClient:
             params=params,
             deserializer=deserializer,
             result_key=result_key,
+            options=options,
         )

--- a/polygon/rest/indicators.py
+++ b/polygon/rest/indicators.py
@@ -29,6 +29,7 @@ class IndicatorsClient(BaseClient):
         params: Optional[Dict[str, Any]] = None,
         series_type: Optional[Union[str, SeriesType]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[SMAIndicatorResults, HTTPResponse]:
         """
         Get SMA values for a given ticker over a given range with the specified parameters
@@ -62,6 +63,7 @@ class IndicatorsClient(BaseClient):
             result_key="results",
             deserializer=SMAIndicatorResults.from_dict,
             raw=raw,
+            options=options,
         )
 
     def get_ema(
@@ -80,6 +82,7 @@ class IndicatorsClient(BaseClient):
         params: Optional[Dict[str, Any]] = None,
         series_type: Optional[Union[str, SeriesType]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[EMAIndicatorResults, HTTPResponse]:
         """
         Get EMA values for a given ticker over a given range with the specified parameters
@@ -131,6 +134,7 @@ class IndicatorsClient(BaseClient):
         params: Optional[Dict[str, Any]] = None,
         series_type: Optional[Union[str, SeriesType]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[RSIIndicatorResults, HTTPResponse]:
         """
         Get RSI values for a given ticker over a given range with the specified parameters
@@ -164,6 +168,7 @@ class IndicatorsClient(BaseClient):
             result_key="results",
             deserializer=RSIIndicatorResults.from_dict,
             raw=raw,
+            options=options,
         )
 
     def get_macd(
@@ -184,6 +189,7 @@ class IndicatorsClient(BaseClient):
         params: Optional[Dict[str, Any]] = None,
         series_type: Optional[Union[str, SeriesType]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[MACDIndicatorResults, HTTPResponse]:
         """
         Get MACD values for a given ticker over a given range with the specified parameters
@@ -218,4 +224,5 @@ class IndicatorsClient(BaseClient):
             result_key="results",
             deserializer=MACDIndicatorResults.from_dict,
             raw=raw,
+            options=options,
         )

--- a/polygon/rest/quotes.py
+++ b/polygon/rest/quotes.py
@@ -27,6 +27,7 @@ class QuotesClient(BaseClient):
         order: Optional[Union[str, Order]] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[Iterator[Quote], HTTPResponse]:
         """
         Get quotes for a ticker symbol in a given time range.
@@ -51,10 +52,15 @@ class QuotesClient(BaseClient):
             params=self._get_params(self.list_quotes, locals()),
             raw=raw,
             deserializer=Quote.from_dict,
+            options=options,
         )
 
     def get_last_quote(
-        self, ticker: str, params: Optional[Dict[str, Any]] = None, raw: bool = False
+        self,
+        ticker: str,
+        params: Optional[Dict[str, Any]] = None,
+        raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[LastQuote, HTTPResponse]:
         """
         Get the most recent NBBO (Quote) tick for a given stock.
@@ -72,6 +78,7 @@ class QuotesClient(BaseClient):
             result_key="results",
             deserializer=LastQuote.from_dict,
             raw=raw,
+            options=options,
         )
 
     def get_last_forex_quote(
@@ -80,6 +87,7 @@ class QuotesClient(BaseClient):
         to: str,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[LastForexQuote, HTTPResponse]:
         """
         Get the last quote tick for a forex currency pair.
@@ -97,6 +105,7 @@ class QuotesClient(BaseClient):
             params=params,
             deserializer=LastForexQuote.from_dict,
             raw=raw,
+            options=options,
         )
 
     def get_real_time_currency_conversion(
@@ -107,6 +116,7 @@ class QuotesClient(BaseClient):
         precision: Union[int, Precision] = 2,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[RealTimeCurrencyConversion, HTTPResponse]:
         """
         Get currency conversions using the latest market conversion rates.
@@ -129,4 +139,5 @@ class QuotesClient(BaseClient):
             params=params,
             deserializer=RealTimeCurrencyConversion.from_dict,
             raw=raw,
+            options=options,
         )

--- a/polygon/rest/reference.py
+++ b/polygon/rest/reference.py
@@ -85,6 +85,7 @@ class TickersClient(BaseClient):
         order: Optional[Union[str, Order]] = "asc",
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[Iterator[Ticker], HTTPResponse]:
         """
         Query all ticker symbols which are supported by Polygon.io. This API currently includes Stocks/Equities, Crypto, and Forex.
@@ -116,6 +117,7 @@ class TickersClient(BaseClient):
             params=self._get_params(self.list_tickers, locals()),
             raw=raw,
             deserializer=Ticker.from_dict,
+            options=options,
         )
 
     def get_ticker_details(
@@ -124,6 +126,7 @@ class TickersClient(BaseClient):
         date: Optional[str] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[TickerDetails, HTTPResponse]:
         """
         Get a single ticker supported by Polygon.io. This response will have detailed information about the ticker and the company behind it.
@@ -142,6 +145,7 @@ class TickersClient(BaseClient):
             deserializer=TickerDetails.from_dict,
             raw=raw,
             result_key="results",
+            options=options,
         )
 
     def get_ticker_events(
@@ -149,6 +153,7 @@ class TickersClient(BaseClient):
         ticker: Optional[str] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[TickerChangeResults, HTTPResponse]:
 
         """
@@ -166,6 +171,7 @@ class TickersClient(BaseClient):
             deserializer=TickerChangeResults.from_dict,
             result_key="results",
             raw=raw,
+            options=options,
         )
 
     def list_ticker_news(
@@ -185,6 +191,7 @@ class TickersClient(BaseClient):
         order: Optional[Union[str, Order]] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[Iterator[TickerNews], HTTPResponse]:
         """
         Get the most recent news articles relating to a stock ticker symbol, including a summary of the article and a link to the original source.
@@ -205,6 +212,7 @@ class TickersClient(BaseClient):
             params=self._get_params(self.list_ticker_news, locals()),
             raw=raw,
             deserializer=TickerNews.from_dict,
+            options=options,
         )
 
     def get_ticker_types(
@@ -213,6 +221,7 @@ class TickersClient(BaseClient):
         locale: Optional[Union[str, Locale]] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[List[TickerTypes], HTTPResponse]:
         """
         List all ticker types that Polygon.io has.
@@ -231,6 +240,7 @@ class TickersClient(BaseClient):
             deserializer=TickerTypes.from_dict,
             raw=raw,
             result_key="results",
+            options=options,
         )
 
 
@@ -253,6 +263,7 @@ class SplitsClient(BaseClient):
         order: Optional[Union[str, Order]] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[Iterator[Split], HTTPResponse]:
         """
         Get a list of historical stock splits, including the ticker symbol, the execution date, and the factors of the split ratio.
@@ -282,6 +293,7 @@ class SplitsClient(BaseClient):
             params=self._get_params(self.list_splits, locals()),
             raw=raw,
             deserializer=Split.from_dict,
+            options=options,
         )
 
 
@@ -325,6 +337,7 @@ class DividendsClient(BaseClient):
         order: Optional[Union[str, Order]] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[Iterator[Dividend], HTTPResponse]:
         """
         Get a list of historical cash dividends, including the ticker symbol, declaration date, ex-dividend date, record date, pay date, frequency, and amount.
@@ -371,6 +384,7 @@ class DividendsClient(BaseClient):
             params=self._get_params(self.list_dividends, locals()),
             raw=raw,
             deserializer=Dividend.from_dict,
+            options=options,
         )
 
 
@@ -386,6 +400,7 @@ class ConditionsClient(BaseClient):
         order: Optional[Union[str, Order]] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[Iterator[Condition], HTTPResponse]:
         """
         List all conditions that Polygon.io uses.
@@ -408,6 +423,7 @@ class ConditionsClient(BaseClient):
             params=self._get_params(self.list_conditions, locals()),
             raw=raw,
             deserializer=Condition.from_dict,
+            options=options,
         )
 
 
@@ -418,6 +434,7 @@ class ExchangesClient(BaseClient):
         locale: Optional[Union[str, Locale]] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[List[Exchange], HTTPResponse]:
         """
         List all exchanges that Polygon.io knows about.
@@ -436,6 +453,7 @@ class ExchangesClient(BaseClient):
             deserializer=Exchange.from_dict,
             raw=raw,
             result_key="results",
+            options=options,
         )
 
 
@@ -446,6 +464,7 @@ class ContractsClient(BaseClient):
         as_of: Optional[Union[str, date]] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[OptionsContract, HTTPResponse]:
         """
         Get the most recent trade for a ticker.
@@ -464,6 +483,7 @@ class ContractsClient(BaseClient):
             result_key="results",
             deserializer=OptionsContract.from_dict,
             raw=raw,
+            options=options,
         )
 
     def list_options_contracts(
@@ -491,6 +511,7 @@ class ContractsClient(BaseClient):
         order: Optional[Union[str, Order]] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[Iterator[OptionsContract], HTTPResponse]:
         """
         List historical options contracts.
@@ -515,4 +536,5 @@ class ContractsClient(BaseClient):
             params=self._get_params(self.list_options_contracts, locals()),
             raw=raw,
             deserializer=OptionsContract.from_dict,
+            options=options,
         )

--- a/polygon/rest/snapshot.py
+++ b/polygon/rest/snapshot.py
@@ -25,6 +25,7 @@ class SnapshotClient(BaseClient):
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
         include_otc: Optional[bool] = False,
+        options: Optional[dict] = None,
     ) -> Union[List[TickerSnapshot], HTTPResponse]:
         """
         Get the most up-to-date market data for all traded stock symbols.
@@ -46,6 +47,7 @@ class SnapshotClient(BaseClient):
             deserializer=TickerSnapshot.from_dict,
             raw=raw,
             result_key="tickers",
+            options=options,
         )
 
     def get_snapshot_direction(
@@ -55,6 +57,7 @@ class SnapshotClient(BaseClient):
         params: Optional[Dict[str, Any]] = None,
         include_otc: Optional[bool] = False,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[List[TickerSnapshot], HTTPResponse]:
         """
         Get the most up-to-date market data for the current top 20 gainers or losers of the day in the stocks/equities markets.
@@ -76,6 +79,7 @@ class SnapshotClient(BaseClient):
             result_key="tickers",
             deserializer=TickerSnapshot.from_dict,
             raw=raw,
+            options=options,
         )
 
     def get_snapshot_ticker(
@@ -84,6 +88,7 @@ class SnapshotClient(BaseClient):
         ticker: str,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[TickerSnapshot, HTTPResponse]:
         """
         Get the most up-to-date market data for all traded stock symbols.
@@ -102,6 +107,7 @@ class SnapshotClient(BaseClient):
             result_key="ticker",
             deserializer=TickerSnapshot.from_dict,
             raw=raw,
+            options=options,
         )
 
     def get_snapshot_option(
@@ -110,6 +116,7 @@ class SnapshotClient(BaseClient):
         option_contract: str,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[OptionContractSnapshot, HTTPResponse]:
         """
         Get the snapshot of an option contract for a stock equity.
@@ -125,6 +132,7 @@ class SnapshotClient(BaseClient):
             result_key="results",
             deserializer=OptionContractSnapshot.from_dict,
             raw=raw,
+            options=options,
         )
 
     def get_snapshot_crypto_book(
@@ -132,6 +140,7 @@ class SnapshotClient(BaseClient):
         ticker: str,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[SnapshotTickerFullBook, HTTPResponse]:
         """
         Get the current level 2 book of a single ticker. This is the combined book from all of the exchanges.
@@ -148,4 +157,5 @@ class SnapshotClient(BaseClient):
             result_key="data",
             deserializer=SnapshotTickerFullBook.from_dict,
             raw=raw,
+            options=options,
         )

--- a/polygon/rest/trades.py
+++ b/polygon/rest/trades.py
@@ -19,6 +19,7 @@ class TradesClient(BaseClient):
         order: Optional[Union[str, Order]] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[Iterator[Trade], HTTPResponse]:
         """
         Get trades for a ticker symbol in a given time range.
@@ -43,6 +44,7 @@ class TradesClient(BaseClient):
             params=self._get_params(self.list_trades, locals()),
             raw=raw,
             deserializer=Trade.from_dict,
+            options=options,
         )
 
     def get_last_trade(
@@ -50,6 +52,7 @@ class TradesClient(BaseClient):
         ticker: str,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[LastTrade, HTTPResponse]:
         """
         Get the most recent trade for a ticker.
@@ -67,6 +70,7 @@ class TradesClient(BaseClient):
             result_key="results",
             deserializer=LastTrade.from_dict,
             raw=raw,
+            options=options,
         )
 
     def get_last_crypto_trade(
@@ -75,6 +79,7 @@ class TradesClient(BaseClient):
         to: str,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[CryptoTrade, HTTPResponse]:
         """
         Get the last trade tick for a cryptocurrency pair.
@@ -93,4 +98,5 @@ class TradesClient(BaseClient):
             result_key="last",
             deserializer=CryptoTrade.from_dict,
             raw=raw,
+            options=options,
         )

--- a/polygon/rest/vX.py
+++ b/polygon/rest/vX.py
@@ -30,6 +30,7 @@ class VXClient(BaseClient):
         order: Optional[Union[str, Order]] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[dict] = None,
     ) -> Union[Iterator[StockFinancial], HTTPResponse]:
         """
         Get historical financial data for a stock ticker.
@@ -65,4 +66,5 @@ class VXClient(BaseClient):
             params=self._get_params(self.list_stock_financials, locals()),
             raw=raw,
             deserializer=StockFinancial.from_dict,
+            options=options,
         )


### PR DESCRIPTION
### Summary
Adding options param to all endpoints to allow for additional request options. This change is being added to support EdgeHeaders that will be needed for Launch pad.

RV1:
- Added `options: Optional[dict]` to all endpoints leading to BaseClient.get. 