### PR TITLE
Param handling

### DIFF
--- a/polygon/rest/quotes.py
+++ b/polygon/rest/quotes.py
@@ -54,7 +54,10 @@ class QuotesClient(BaseClient):
         )
 
     def get_last_quote(
-        self, ticker: str, params: Optional[Dict[str, Any]] = None, raw: bool = False
+            self,
+            ticker: str,
+            params: Optional[Dict[str, Any]] = None,
+            raw: bool = False
     ) -> Union[LastQuote, HTTPResponse]:
         """
         Get the most recent NBBO (Quote) tick for a given stock.
@@ -120,13 +123,10 @@ class QuotesClient(BaseClient):
         :return: Real-Time Currency Conversion
         """
         url = f"/v1/conversion/{from_}/{to}"
-        if params is None:
-            params = {}
-        params["amount"] = amount
-        params["precision"] = precision
+
         return self._get(
             path=url,
-            params=params,
+            params=self._get_params(self.get_real_time_currency_conversion, locals()),
             deserializer=RealTimeCurrencyConversion.from_dict,
             raw=raw,
         )

--- a/polygon/rest/quotes.py
+++ b/polygon/rest/quotes.py
@@ -54,10 +54,7 @@ class QuotesClient(BaseClient):
         )
 
     def get_last_quote(
-            self,
-            ticker: str,
-            params: Optional[Dict[str, Any]] = None,
-            raw: bool = False
+        self, ticker: str, params: Optional[Dict[str, Any]] = None, raw: bool = False
     ) -> Union[LastQuote, HTTPResponse]:
         """
         Get the most recent NBBO (Quote) tick for a given stock.

--- a/polygon/rest/reference.py
+++ b/polygon/rest/reference.py
@@ -227,7 +227,7 @@ class TickersClient(BaseClient):
 
         return self._get(
             path=url,
-            params=params,
+            params=self._get_params(self.get_ticker_types, locals()),
             deserializer=TickerTypes.from_dict,
             raw=raw,
             result_key="results",
@@ -432,7 +432,7 @@ class ExchangesClient(BaseClient):
 
         return self._get(
             path=url,
-            params=params,
+            params=self._get_params(self.get_exchanges, locals()),
             deserializer=Exchange.from_dict,
             raw=raw,
             result_key="results",


### PR DESCRIPTION
functions directly setting params via argument value vs get_params function. Some functions were not passing arguments to request due to absence of function usage.

Ex.
params=params # directly set
params=self._get_params(self.<function>, locals()) # uses all local arguments to build params passed to api.

Additional question.
in base._get() we are creating params if params are None. this pattern is the same pattern used with "_get_params()" and I believe it can be removed. I will need to test to confirm.
# Todo: investigate refactoring all apis to use self._get_params(fn, dict) function