### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,110 @@ Python client for the [Polygon.io API](https://polygon.io).
 
 ## Install
 
-`pip install polygon-api-client`
-
+```
+pip install polygon-api-client
+```
 Requires Python >= 3.8.
 
 ## Getting started
 See the [Getting Started](https://polygon-api-client.readthedocs.io/en/latest/Getting-Started.html)
-section in our docs or view the [examples](./examples) directory.
+section in our docs or view the [examples](./examples) directory for additional examples.
+## REST API Client
+Import the RESTClient.
+```python
+from polygon import RESTClient
+```
+Create a new client with your [API key](https://polygon.io/dashboard/api-keys)
+```python
+client = RESTClient(api_key="<API_KEY>")
+```
+### Using the Client
+Request data using client methods.
+```python
+ticker = "AAPL"
 
-#### Launchpad Usage
+# List Aggregates (Bars)
+bars = client.get_aggs(ticker=ticker, multiplier=1, timespan="day", from_="2023-01-09", to="2023-01-10")
+for bar in bars:
+    print(bar)
 
-Users of the Launchpad product will need to pass in certain headers in order to make API requests.
+# Get Last Trade
+trade = client.get_last_trade(ticker=ticker)
+print(trade)
+
+# List Trades
+trades = client.list_trades(ticker=ticker, timestamp="2022-01-04")
+for trade in trades:
+    print(trade)
+
+# Get Last Quote
+quote = client.get_last_quote(ticker=ticker)
+print(quote)
+
+# List Quotes
+quotes = client.list_quotes(ticker=ticker, timestamp="2022-01-04")
+for quote in quotes:
+    print(quote)
+```
+Note: For parameter argument examples check out our docs. All required arguments are annotated with red asterisks " * " and argument examples are set.
+Check out an example for Aggregates(client.get_aggs) [here](https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__range__multiplier___timespan___from___to)
+
+## Launchpad
+Users of the Launchpad product will need to pass in certain headers in order to make API requests using the RequestOptionBuilder.
 Example can be found [here](./examples/launchpad).
+
+Import classes
+```python
+from polygon import RESTClient
+from polygon.rest.models.request import RequestOptionBuilder
+```
+### Using the client
+Create client and set options
+```python
+# create client
+c = RESTClient(api_key="API_KEY")
+
+# create request options
+options = RequestOptionBuilder().edge_headers(
+    edge_id="YOUR_EDGE_ID",  # required
+    edge_ip_address="IP_ADDRESS",  # required
+)
+```
+Request data using client methods.
+```python
+# get response
+res = c.get_aggs("AAPL", 1, "day", "2022-04-04", "2022-04-04", options=options)
+
+# do something with response
+```
+Checkout Launchpad readme for more details on RequestOptionBuilder [here](./examples/launchpad)
+
+## WebSocket Client 
+
+Import classes
+```python
+from polygon import WebSocketClient
+from polygon.websocket.models import WebSocketMessage
+from typing import List
+```
+### Using the client
+Create a new client with your [API key](https://polygon.io/dashboard/api-keys) and subscription options.
+```python
+# Note: Multiple subscriptions can be added to the array 
+# For example, if you want to subscribe to AAPL and META,
+# you can do so by adding "T.META" to the subscriptions array. ["T.AAPL", "T.META"]
+# If you want to subscribe to all tickers, place an asterisk in place of the symbol. ["T.*"]
+ws = WebSocketClient(api_key=<API_KEY>, subscriptions=["T.AAPL"])
+```
+Create a handler function and run the WebSocket.
+```python
+def handle_msg(msg: List[WebSocketMessage]):
+    for m in msg:
+        print(m)
+
+ws.run(handle_msg=handle_msg)
+```
+Check out more detailed examples [here](https://github.com/polygon-io/client-python/tree/master/examples/websocket).
 
 ## Contributing
 

--- a/polygon/rest/summaries.py
+++ b/polygon/rest/summaries.py
@@ -5,6 +5,8 @@ from .models import Order
 from urllib3 import HTTPResponse
 from datetime import datetime, date
 
+from .models.request import RequestOptionBuilder
+
 
 class SummariesClient(BaseClient):
     def get_summaries(
@@ -12,6 +14,7 @@ class SummariesClient(BaseClient):
         ticker_any_of: Optional[List[str]] = None,
         params: Optional[Dict[str, Any]] = None,
         raw: bool = False,
+        options: Optional[RequestOptionBuilder] = None,
     ) -> Union[List[SummaryResult], HTTPResponse]:
         """
         GetSummaries retrieves summaries for the ticker list with the given params.
@@ -30,4 +33,5 @@ class SummariesClient(BaseClient):
             result_key="results",
             deserializer=SummaryResult.from_dict,
             raw=raw,
+            options=options,
         )

--- a/polygon/rest/summaries.py
+++ b/polygon/rest/summaries.py
@@ -1,9 +1,7 @@
 from polygon.rest.models.summaries import SummaryResult
 from .base import BaseClient
-from typing import Optional, Any, Dict, List, Union, Iterator
-from .models import Order
+from typing import Optional, Any, Dict, List, Union
 from urllib3 import HTTPResponse
-from datetime import datetime, date
 
 from .models.request import RequestOptionBuilder
 


### PR DESCRIPTION
Addressing [ticket](https://app.zenhub.com/workspaces/backend-6042935fc77665000f50780e/issues/gh/polygon-io/backend/862)


Updating README to include examples and Quickstart guide so users don't need to navigate to multiple pages. 
- Added Examples for RESTClient
- Added Example for WebSocketClient
- Added Example for Launchpad.

This update is based on the README used in client-go with more brevity of steps.