### PR TITLE
Fix malformed query filter params

### DIFF
--- a/polygon/rest/base.py
+++ b/polygon/rest/base.py
@@ -141,14 +141,12 @@ class BaseClient:
                 elif isinstance(val, datetime):
                     val = int(val.timestamp() * self.time_mult(datetime_res))
                 if val is not None:
-                    if (
-                        argname.endswith("_lt")
-                        or argname.endswith("_lte")
-                        or argname.endswith("_gt")
-                        or argname.endswith("_gte")
-                        or argname.endswith("_any_of")
-                    ):
-                        argname = ".".join(argname.split("_", 1))
+                    for ext in ["lt", "lte", "gt", "gte", "any_of"]:
+                        if argname.endswith(f"_{ext}"):
+                            # lop off ext, then rebuild argname with ext,
+                            # using ., and not _ (removesuffix would work)
+                            # but that is python 3.9+
+                            argname = argname[: -len(f"_{ext}")] + f".{ext}"
                     if argname.endswith("any_of"):
                         val = ",".join(val)
                     params[argname] = val


### PR DESCRIPTION
There are two bugs https://github.com/polygon-io/client-python/issues/382 and https://github.com/polygon-io/client-python/issues/388 that have reported query filter extensions ("lt", "lte", "gt", "gte", "any_of") are not working as expected. Thanks to the debug work of `jakekdodd` it was easy to track down the source of the bug.

Examples of the malformed params being passed to the API before the fix:
- `expiration.date_gte`
- `strike.price_gte`

Examples of what these should look like:
- `expiration_date.gte`
- `strike_price.gte`

Example 1 - code to test (these should both get you the same result):

```python
from polygon import RESTClient
client = RESTClient()

foo = client.list_options_contracts(underlying_ticker='HCP', expiration_date_gte='2024-03-16', contract_type='call', strike_price_gte=20)

for p in foo:
    print(p)

bar = client.list_options_contracts(
    underlying_ticker="HCP",
    contract_type="call",
    params={
        "expiration_date.gte": "2024-03-16",
        "strike_price.gte": 20,
    },
)

for p in bar:
    print(p)
```

Example 2 - code to test (these should both get you the same result):

```python
from polygon import RESTClient
import datetime
client = RESTClient()

foo = client.vx.list_stock_financials(ticker="AAPL", timeframe='annual', period_of_report_date_gte=str(datetime.date(2017, 1, 1)), period_of_report_date_lt=str(datetime.date(2021, 1, 1)))

for report in foo:
    print(f"{report.fiscal_year=}, {report.fiscal_period=}")

bar = client.vx.list_stock_financials(
    ticker="AAPL", 
    timeframe='annual', 
    params={
        "period_of_report_date.gte": str(datetime.date(2017, 1, 1)),
        "period_of_report_date.lt": str(datetime.date(2021, 1, 1)),
    },
)

for report in bar:
    print(f"{report.fiscal_year=}, {report.fiscal_period=}")
```

Note: I didn't end up using the suggested code from the bug report, since removesuffix requires python 3.9, and we say the client library should work with 3.8. So, didn't want to break a bunch of existing code.

Credits: Thanks for the great debug work @jakekdodd.