### PR TITLE
Fix for failing dependabot PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup Poetry
-        uses: abatilo/actions-poetry@v2.0.0
+        uses: abatilo/actions-poetry@v2
       - name: Install pypi deps
         run: poetry install
       - name: Style lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Setup Poetry
-        uses: abatilo/actions-poetry@v2.0.0
+        uses: abatilo/actions-poetry@v2
       - name: Install pypi deps
         run: poetry install
       - name: Unit tests


### PR DESCRIPTION
We have multiple PRs from dependabot where the linting and unit tests are failing with the error below. Turns out that dependabot is running an updated version of poetry where the syntax of the `poetry.lock` has been updated. So, when it submits patches our version of the `abatilo/actions-poetry@v2.0.0` github action cannot parse the `poetry.lock` syntax and fails. There is no support to revert dependabot to an older version of poetry (open issue here: https://github.com/dependabot/dependabot-core/issues/1556).

Error we are seeing:

```
[NonExistentKey]
'Key "files" does not exist.'
Error: Process completed with exit code 1.
```

So, it seems our only fix is to update the gitub action to support the poetry version that dependabot is using so we can parse the `poetry.lock` syntax. I have run a successful test by manually tweaking the github actions along with bumping the version of types-setuptools and got the linting and tests to pass (https://github.com/polygon-io/client-python/pull/394). 

My plan here is to bump the version of the github action with this PR. Then, we'll get dependabot to recreate it's patches and we should have an automated system again.

Here's the PRs this patch will unblock:

- https://github.com/polygon-io/client-python/pull/393
- https://github.com/polygon-io/client-python/pull/381
- https://github.com/polygon-io/client-python/pull/375
- https://github.com/polygon-io/client-python/pull/362
- https://github.com/polygon-io/client-python/pull/359