### PR TITLE
Force gzip encoding for faster response and reduced bandwidth usage

### DIFF
--- a/polygon/rest/base.py
+++ b/polygon/rest/base.py
@@ -41,6 +41,7 @@ class BaseClient:
 
         self.headers = {
             "Authorization": "Bearer " + self.API_KEY,
+            "Accept-Encoding": "gzip",
             "User-Agent": f"Polygon.io PythonClient/{version}",
         }
 


### PR DESCRIPTION
Enables gzip encoding for all HTTP requests, by adding the "Accept-Encoding: gzip" header to the request. Gzip encoding compresses the response body before sending it to the client, which reduces the size of the response and saves bandwidth.

Urllib3 supports gzip encoding out of the box. By default, urllib3 will automatically decode the gzip response if the server returns a compressed response. So, we are explicitly requesting gzip encoding via the request headers, by adding setting the Accept-Encoding header to gzip.

By enabling gzip encoding, we expect to see faster download times and reduced bandwidth usage for our users.

Server response headers without gzip:

```
Response headers:
Server: nginx/1.19.2
Date: Mon, 20 Mar 2023 20:40:30 GMT
Content-Type: application/json
Transfer-Encoding: chunked
Connection: keep-alive
Vary: Accept-Encoding
X-Request-Id: 630f6cb5bc2c0a317e19de7ad7255093
Strict-Transport-Security: max-age=15724800; includeSubDomains
```

Server response headers with gzip:

```
Response headers:
Server: nginx/1.19.2
Date: Mon, 20 Mar 2023 20:41:58 GMT
Content-Type: application/json
Content-Length: 1111
Connection: keep-alive
Content-Encoding: gzip
Vary: Accept-Encoding
X-Request-Id: 0fe30e077d618524ec16ec754cb96b58
Strict-Transport-Security: max-age=15724800; includeSubDomains
```

Client returns same results in both case.