### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           python-version: "3.10"
       - name: Setup Poetry
-        uses: abatilo/actions-poetry@v2.0.0
+        uses: abatilo/actions-poetry@v2
         with:
           poetry-version: "1.1.13"
       - name: Configure Poetry


### PR DESCRIPTION
In https://github.com/polygon-io/client-python/pull/395 we fixed a gitub action to support the poetry version that dependabot is using so we can parse the poetry.lock syntax. However, this [broke the automated release pipeline](https://github.com/polygon-io/client-python/actions/workflows/release.yml) to https://pypi.org/project/polygon-api-client/ since we needed to update it's ability to parse the new poetry.lock syntax too.

The impact here is that we have not released 1.8.x.

This will fix the broken release action here: https://github.com/polygon-io/client-python/actions/workflows/release.yml