### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ jobs:
           python-version: "3.10"
       - name: Setup Poetry
         uses: abatilo/actions-poetry@v2
-        with:
-          poetry-version: "1.1.13"
       - name: Configure Poetry
         run: poetry config pypi-token.pypi ${{ secrets.POETRY_HTTP_BASIC_PYPI_PASSWORD }}
       - name: Install pypi deps


### PR DESCRIPTION
In #395 and #413 we fixed a gitub action to support the poetry version that dependabot is using so we can parse the poetry.lock syntax. However, this broke the automated release pipeline to [pypi.org](https://pypi.org/project/polygon-api-client/) since we needed to update it's ability to parse the new poetry.lock syntax too.

The impact here is that we have not released 1.8.x.