### PR TITLE
Added indices to market status

### DIFF
--- a/polygon/rest/models/markets.py
+++ b/polygon/rest/models/markets.py
@@ -80,6 +80,9 @@ class MarketStatus:
             exchanges=None
             if "exchanges" not in d
             else MarketExchanges.from_dict(d["exchanges"]),
+            indicesGroups=None
+            if "indicesGroups" not in d
+            else MarketIndices.from_dict(d["indicesGroups"]),
             market=d.get("market", None),
             server_time=d.get("serverTime", None),
         )


### PR DESCRIPTION
Added indices to return when calling market status.

Before:

MarketStatus(after_hours=False, currencies=MarketCurrencies(crypto='open', fx='open'), early_hours=True, exchanges=MarketExchanges(nasdaq='extended-hours', nyse='extended-hours', otc='extended-hours'), indicesGroups=None, market='extended-hours', server_time='2023-03-29T08:59:42-04:00')

After:

MarketStatus(after_hours=False, currencies=MarketCurrencies(crypto='open', fx='open'), early_hours=True, exchanges=MarketExchanges(nasdaq='extended-hours', nyse='extended-hours', otc='extended-hours'), indicesGroups=MarketIndices(s_and_p='open', societe_generale='open', msci='closed', ftse_russell='closed', mstar='open', mstarc='open', cccy='open', nasdaq='closed', dow_jones='closed'), market='extended-hours', server_time='2023-03-29T09:06:35-04:00')