### PR TITLE
Fix ws IndexValue parse

### DIFF
--- a/polygon/websocket/models/__init__.py
+++ b/polygon/websocket/models/__init__.py
@@ -26,6 +26,8 @@ def parse_single(data: Dict[str, Any]):
         return LimitUpLimitDown.from_dict(data)
     elif event_type == EventType.CryptoL2.value:
         return Level2Book.from_dict(data)
+    elif event_type == EventType.Value.value:
+        return IndexValue.from_dict(data)
     return None
 
 

--- a/polygon/websocket/models/models.py
+++ b/polygon/websocket/models/models.py
@@ -317,10 +317,12 @@ class IndexValue:
 
     @staticmethod
     def from_dict(d):
-        d.get("ev", None),
-        d.get("val", None),
-        d.get("T", None),
-        d.get("t", None)
+        return IndexValue(
+            d.get("ev", None),
+            d.get("val", None),
+            d.get("T", None),
+            d.get("t", None),
+        )
 
 
 WebSocketMessage = NewType(


### PR DESCRIPTION
When subscribed to the real-time value for a given index ticker symbol with python it was throwing an error saying unknown message type. So, updated the `parse_single` to recognize the event type and then updated the `IndexValue` class to return the correct message type.

Here's a test script:

```python
from polygon import WebSocketClient
from polygon.websocket.models import WebSocketMessage, Market
from typing import List

client = WebSocketClient(market=Market.Indices)

client.subscribe("V.I:SPX") # Standard & Poor's 500

def handle_msg(msgs: List[WebSocketMessage]):
    for m in msgs:
        print(m)

client.run(handle_msg)
```