### PR TITLE
Update reference.py to include indices

### DIFF
--- a/polygon/rest/reference.py
+++ b/polygon/rest/reference.py
@@ -90,7 +90,7 @@ class TickersClient(BaseClient):
         options: Optional[RequestOptionBuilder] = None,
     ) -> Union[Iterator[Ticker], HTTPResponse]:
         """
-        Query all ticker symbols which are supported by Polygon.io. This API currently includes Stocks/Equities, Crypto, and Forex.
+        Query all ticker symbols which are supported by Polygon.io. This API currently includes Stocks/Equities, Indices, Forex, and Crypto.
 
         :param ticker: Specify a ticker symbol. Defaults to empty string which queries all tickers.
         :param ticker_lt: Ticker less than.


### PR DESCRIPTION
The v3 Tickers endpoint supports indices too. Minor tweak here to fix this comment.