### PR TITLE
Updated Examples and Docs to Support Agg Pagination

### DIFF
--- a/docs/source/Aggs.rst
+++ b/docs/source/Aggs.rst
@@ -4,6 +4,17 @@ Aggs
 ==========
 
 ===========
+List aggs
+===========
+
+- `Stocks aggs`_
+- `Options aggs`_
+- `Forex aggs`_
+- `Crypto aggs`_
+
+.. automethod:: polygon.RESTClient.list_aggs
+
+===========
 Get aggs
 ===========
 

--- a/examples/rest/crypto-aggregates_bars.py
+++ b/examples/rest/crypto-aggregates_bars.py
@@ -2,7 +2,7 @@ from polygon import RESTClient
 
 # docs
 # https://polygon.io/docs/crypto/get_v2_aggs_ticker__cryptoticker__range__multiplier___timespan___from___to
-# https://polygon-api-client.readthedocs.io/en/latest/Aggs.html#polygon.RESTClient.get_aggs
+# https://polygon-api-client.readthedocs.io/en/latest/Aggs.html#polygon.RESTClient.list_aggs
 
 # API key injected below for easy use. If not provided, the script will attempt
 # to use the environment variable "POLYGON_API_KEY".
@@ -16,12 +16,15 @@ from polygon import RESTClient
 # client = RESTClient("XXXXXX") # hardcoded api_key is used
 client = RESTClient()  # POLYGON_API_KEY environment variable is used
 
-aggs = client.get_aggs(
+aggs = []
+for a in client.list_aggs(
     "X:BTCUSD",
     1,
     "day",
     "2023-01-30",
     "2023-02-03",
-)
+    limit=50000,
+):
+    aggs.append(a)
 
 print(aggs)

--- a/examples/rest/forex-aggregates_bars.py
+++ b/examples/rest/forex-aggregates_bars.py
@@ -2,7 +2,7 @@ from polygon import RESTClient
 
 # docs
 # https://polygon.io/docs/forex/get_v2_aggs_ticker__forexticker__range__multiplier___timespan___from___to
-# https://polygon-api-client.readthedocs.io/en/latest/Aggs.html#polygon.RESTClient.get_aggs
+# https://polygon-api-client.readthedocs.io/en/latest/Aggs.html#polygon.RESTClient.list_aggs
 
 # API key injected below for easy use. If not provided, the script will attempt
 # to use the environment variable "POLYGON_API_KEY".
@@ -16,12 +16,15 @@ from polygon import RESTClient
 # client = RESTClient("XXXXXX") # hardcoded api_key is used
 client = RESTClient()  # POLYGON_API_KEY environment variable is used
 
-aggs = client.get_aggs(
+aggs = []
+for a in client.list_aggs(
     "C:EURUSD",
     1,
     "day",
     "2023-01-30",
     "2023-02-03",
-)
+    limit=50000,
+):
+    aggs.append(a)
 
 print(aggs)

--- a/examples/rest/indices-aggregates_bars.py
+++ b/examples/rest/indices-aggregates_bars.py
@@ -2,7 +2,7 @@ from polygon import RESTClient
 
 # docs
 # https://polygon.io/docs/indices/get_v2_aggs_ticker__indicesticker__range__multiplier___timespan___from___to
-# https://polygon-api-client.readthedocs.io/en/latest/Aggs.html#polygon.RESTClient.get_aggs
+# https://polygon-api-client.readthedocs.io/en/latest/Aggs.html#polygon.RESTClient.list_aggs
 
 # API key injected below for easy use. If not provided, the script will attempt
 # to use the environment variable "POLYGON_API_KEY".
@@ -16,12 +16,15 @@ from polygon import RESTClient
 # client = RESTClient("XXXXXX") # hardcoded api_key is used
 client = RESTClient()  # POLYGON_API_KEY environment variable is used
 
-aggs = client.get_aggs(
+aggs = []
+for a in client.list_aggs(
     "I:SPX",
     1,
     "day",
     "2023-03-10",
-    "2023-03-10",
-)
+    "2023-05-12",
+    limit=50000,
+):
+    aggs.append(a)
 
 print(aggs)

--- a/examples/rest/options-aggregates_bars.py
+++ b/examples/rest/options-aggregates_bars.py
@@ -2,7 +2,7 @@ from polygon import RESTClient
 
 # docs
 # https://polygon.io/docs/options/get_v2_aggs_ticker__optionsticker__range__multiplier___timespan___from___to
-# https://polygon-api-client.readthedocs.io/en/latest/Aggs.html#polygon.RESTClient.get_aggs
+# https://polygon-api-client.readthedocs.io/en/latest/Aggs.html#polygon.RESTClient.list_aggs
 
 # API key injected below for easy use. If not provided, the script will attempt
 # to use the environment variable "POLYGON_API_KEY".
@@ -16,12 +16,15 @@ from polygon import RESTClient
 # client = RESTClient("XXXXXX") # hardcoded api_key is used
 client = RESTClient()  # POLYGON_API_KEY environment variable is used
 
-aggs = client.get_aggs(
+aggs = []
+for a in client.list_aggs(
     "O:SPY251219C00650000",
     1,
     "day",
     "2023-01-30",
     "2023-02-03",
-)
+    limit=50000,
+):
+    aggs.append(a)
 
 print(aggs)

--- a/examples/rest/stocks-aggregates_bars.py
+++ b/examples/rest/stocks-aggregates_bars.py
@@ -2,7 +2,7 @@ from polygon import RESTClient
 
 # docs
 # https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__range__multiplier___timespan___from___to
-# https://polygon-api-client.readthedocs.io/en/latest/Aggs.html#polygon.RESTClient.get_aggs
+# https://polygon-api-client.readthedocs.io/en/latest/Aggs.html#polygon.RESTClient.list_aggs
 
 # API key injected below for easy use. If not provided, the script will attempt
 # to use the environment variable "POLYGON_API_KEY".
@@ -14,14 +14,17 @@ from polygon import RESTClient
 # to the shell startup script (e.g. .bashrc or .bash_profile.
 #
 # client = RESTClient("XXXXXX") # hardcoded api_key is used
-client = RESTClient()  # POLYGON_API_KEY environment variable is used
+client = RESTClient(trace=True)  # POLYGON_API_KEY environment variable is used
 
-aggs = client.get_aggs(
+aggs = []
+for a in client.list_aggs(
     "AAPL",
     1,
-    "day",
-    "2023-01-30",
+    "minute",
+    "2022-01-01",
     "2023-02-03",
-)
+    limit=50000,
+):
+    aggs.append(a)
 
 print(aggs)

--- a/examples/rest/stocks-aggregates_bars.py
+++ b/examples/rest/stocks-aggregates_bars.py
@@ -14,7 +14,7 @@ from polygon import RESTClient
 # to the shell startup script (e.g. .bashrc or .bash_profile.
 #
 # client = RESTClient("XXXXXX") # hardcoded api_key is used
-client = RESTClient(trace=True)  # POLYGON_API_KEY environment variable is used
+client = RESTClient()  # POLYGON_API_KEY environment variable is used
 
 aggs = []
 for a in client.list_aggs(

--- a/examples/rest/stocks-aggregates_bars_extra.py
+++ b/examples/rest/stocks-aggregates_bars_extra.py
@@ -16,18 +16,21 @@ import io
 
 # docs
 # https://polygon.io/docs/stocks/get_v2_aggs_ticker__stocksticker__range__multiplier___timespan___from___to
-# https://polygon-api-client.readthedocs.io/en/latest/Aggs.html#polygon.RESTClient.get_aggs
+# https://polygon-api-client.readthedocs.io/en/latest/Aggs.html#polygon.RESTClient.list_aggs
 
 # client = RESTClient("XXXXXX") # hardcoded api_key is used
 client = RESTClient()  # POLYGON_API_KEY environment variable is used
 
-aggs = client.get_aggs(
+aggs = []
+for a in client.list_aggs(
     "AAPL",
     1,
     "hour",
     "2023-01-30",
     "2023-02-03",
-)
+    limit=50000,
+):
+    aggs.append(a)
 
 print(aggs)
 

--- a/examples/rest/stocks-aggregates_bars_highcharts.py
+++ b/examples/rest/stocks-aggregates_bars_highcharts.py
@@ -70,14 +70,16 @@ Highcharts.getJSON('/data', function (data) {
 
 client = RESTClient()  # POLYGON_API_KEY environment variable is used
 
-aggs = client.get_aggs(
+aggs = []
+for a in client.list_aggs(
     "AAPL",
     1,
     "day",
     "2019-01-01",
     "2023-02-16",
     limit=50000,
-)
+):
+    aggs.append(a)
 
 # print(aggs)
 


### PR DESCRIPTION
Updated the examples and documentation with agg pagination support. Users previously had to fetch aggregate data in smaller chunks to conform to the 50k API limit, however with the inclusion of automatic pagination, the client now seamlessly handles large data requests. This update greatly improves usability and efficiency when working with substantial datasets.