### PR TITLE
Return empty array instead of raising NoResultsError for missing results

### DIFF
--- a/docs/source/Exceptions.rst
+++ b/docs/source/Exceptions.rst
@@ -17,10 +17,3 @@ BadResponse
     :members:
     :undoc-members:  
 
-==============================================================
-NoResultsError
-==============================================================
-.. autoclass:: polygon.exceptions.NoResultsError
-    :members:
-    :undoc-members:  
-

--- a/polygon/exceptions.py
+++ b/polygon/exceptions.py
@@ -12,11 +12,3 @@ class BadResponse(Exception):
     """
 
     pass
-
-
-class NoResultsError(Exception):
-    """
-    Missing results key
-    """
-
-    pass

--- a/polygon/rest/base.py
+++ b/polygon/rest/base.py
@@ -116,11 +116,7 @@ class BaseClient:
 
         if result_key:
             if result_key not in obj:
-                raise NoResultsError(
-                    f'Expected key "{result_key}" in response {obj}.'
-                    + "Make sure you have sufficient permissions and your request parameters are valid."
-                    + f"This is the url that returned no results: {resp.geturl()}"
-                )
+                return []
             obj = obj[result_key]
 
         if deserializer:
@@ -198,6 +194,8 @@ class BaseClient:
                 options=options,
             )
             decoded = self._decode(resp)
+            if result_key not in decoded:
+                return []
             for t in decoded[result_key]:
                 yield deserializer(t)
             if "next_url" in decoded:


### PR DESCRIPTION
This PR modifies the `_get` and `_paginate_iter` functions to return an empty array instead of raising a `NoResultsError` when no results are found. This change makes it consistent with the client-go library but more importantly with what users typically expect. By returning an empty array, the code is easier to deal with and understand from a user perspective, and it resolves concerns expressed in two open user issues ([#467](https://github.com/polygon-io/client-python/issues/467) and [#474](https://github.com/polygon-io/client-python/issues/474)).

I have also removed `NoResultsError` from the code since `_get` was the only place it was used. `_paginate_iter` did not correctly handle errors when no results were found. After exploring issue [#474](https://github.com/polygon-io/client-python/issues/474), it seems rather than throwing another `NoResultsError`, we should probably change this for both `_get` and `_paginate_iter` to just return an empty array like client-go.

Also, this removes a hurdle for users of the client-python library. In that when they get zero results, their program will crash, they will need to explore why, and then add additional handling and imports. We solve all this upfront by doing what it typically expected.