### PR TITLE
Fix parameter naming and add missing parameters in list_universal_snapshots

### DIFF
--- a/examples/rest/universal-snapshot.py
+++ b/examples/rest/universal-snapshot.py
@@ -10,6 +10,7 @@ from polygon.rest.models import UniversalSnapshot, SnapshotMarketType
 # client = RESTClient("XXXXXX") # hardcoded api_key is used
 client = RESTClient()  # POLYGON_API_KEY environment variable is used
 
+
 def print_snapshots(iterator: Union[Iterator[UniversalSnapshot], HTTPResponse]):
     snapshots = [s for s in iterator]
 
@@ -32,17 +33,15 @@ it = client.list_universal_snapshots(
 )
 print_snapshots(it)
 
-it = client.list_universal_snapshots(
-    type="stocks", ticker_gt="A", ticker_lt="AAPL"
-)
+it = client.list_universal_snapshots(type="stocks", ticker_gt="A", ticker_lt="AAPL")
+print_snapshots(it)
+
+it = client.list_universal_snapshots(type="stocks", ticker_gte="AAPL", ticker_lte="ABB")
 print_snapshots(it)
 
 it = client.list_universal_snapshots(
-    type="stocks", ticker_gte="AAPL", ticker_lte="ABB"
-)
-print_snapshots(it)
-
-it = client.list_universal_snapshots(
-    type="options", ticker_gte="O:AAPL230804C00050000", ticker_lte="O:AAPL230804C00070000"
+    type="options",
+    ticker_gte="O:AAPL230804C00050000",
+    ticker_lte="O:AAPL230804C00070000",
 )
 print_snapshots(it)

--- a/examples/rest/universal-snapshot.py
+++ b/examples/rest/universal-snapshot.py
@@ -8,7 +8,7 @@ from polygon.rest.models import UniversalSnapshot, SnapshotMarketType
 # https://polygon-api-client.readthedocs.io/en/latest/Snapshot.html
 
 # client = RESTClient("XXXXXX") # hardcoded api_key is used
-client = RESTClient(trace=True)  # POLYGON_API_KEY environment variable is used
+client = RESTClient()  # POLYGON_API_KEY environment variable is used
 
 def print_snapshots(iterator: Union[Iterator[UniversalSnapshot], HTTPResponse]):
     snapshots = [s for s in iterator]

--- a/examples/rest/universal-snapshot.py
+++ b/examples/rest/universal-snapshot.py
@@ -1,7 +1,5 @@
 from typing import cast, Iterator, Union
-
 from urllib3 import HTTPResponse
-
 from polygon import RESTClient
 from polygon.rest.models import UniversalSnapshot, SnapshotMarketType
 
@@ -10,8 +8,7 @@ from polygon.rest.models import UniversalSnapshot, SnapshotMarketType
 # https://polygon-api-client.readthedocs.io/en/latest/Snapshot.html
 
 # client = RESTClient("XXXXXX") # hardcoded api_key is used
-client = RESTClient()  # POLYGON_API_KEY environment variable is used
-
+client = RESTClient(trace=True)  # POLYGON_API_KEY environment variable is used
 
 def print_snapshots(iterator: Union[Iterator[UniversalSnapshot], HTTPResponse]):
     snapshots = [s for s in iterator]
@@ -36,11 +33,16 @@ it = client.list_universal_snapshots(
 print_snapshots(it)
 
 it = client.list_universal_snapshots(
-    market_type=SnapshotMarketType.STOCKS, ticker_gt="A", ticker_lt="AAPL"
+    type="stocks", ticker_gt="A", ticker_lt="AAPL"
 )
 print_snapshots(it)
 
 it = client.list_universal_snapshots(
-    market_type=SnapshotMarketType.STOCKS, ticker_gte="AAPL", ticker_lte="ABB"
+    type="stocks", ticker_gte="AAPL", ticker_lte="ABB"
+)
+print_snapshots(it)
+
+it = client.list_universal_snapshots(
+    type="options", ticker_gte="O:AAPL230804C00050000", ticker_lte="O:AAPL230804C00070000"
 )
 print_snapshots(it)

--- a/polygon/rest/snapshot.py
+++ b/polygon/rest/snapshot.py
@@ -8,6 +8,8 @@ from .models import (
     SnapshotTickerFullBook,
     UniversalSnapshot,
     IndicesSnapshot,
+    Sort,
+    Order,
 )
 from urllib3 import HTTPResponse
 
@@ -24,8 +26,11 @@ def get_locale(market_type: Union[SnapshotMarketType, str]):
 class SnapshotClient(BaseClient):
     def list_universal_snapshots(
         self,
-        market_type: Optional[Union[str, SnapshotMarketType]] = None,
+        type: Optional[Union[str, SnapshotMarketType]] = None,
         ticker_any_of: Optional[List[str]] = None,
+        order: Optional[Union[str, Order]] = None,
+        limit: Optional[int] = 10,
+        sort: Optional[Union[str, Sort]] = None,
         ticker_lt: Optional[str] = None,
         ticker_lte: Optional[str] = None,
         ticker_gt: Optional[str] = None,
@@ -42,8 +47,11 @@ class SnapshotClient(BaseClient):
         - https://polygon.io/docs/forex/get_v3_snapshot
         - https://polygon.io/docs/crypto/get_v3_snapshot
 
-        :param market_type: the type of the asset
+        :param type: the type of the asset
         :param ticker_any_of: Comma-separated list of tickers, up to a maximum of 250. If no tickers are passed then all
+        :param order: The order to sort the results on. Default is asc (ascending).
+        :param limit: Limit the size of the response per-page, default is 10 and max is 250.
+        :param sort: The field to sort the results on. Default is ticker. If the search query parameter is present, sort is ignored and results are ordered by relevance.
         results will be returned in a paginated manner. Warning: The maximum number of characters allowed in a URL
         are subject to your technology stack.
         :param ticker_lt search for tickers less than


### PR DESCRIPTION
This PR fixes the issue reported in [#476](https://github.com/polygon-io/client-python/issues/476), where the `market_type` parameter was incorrectly named and several other parameters were missing in the `list_universal_snapshots` method of the `SnapshotClient` class. The updates made in this PR align the code with the expected behavior and fixes a bug in universal snapshots retrieval by renaming the `market_type` parameter to `type` and adding the missing parameters `order`, `limit`, and `sort`. The corresponding example has also been updated to reflect these changes.