### PR TITLE
Update urllib3 release channel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-urllib3 = "^1.26.9"
+urllib3 = "^1.26.9,<2.0"
 websockets = ">=10.3,<12.0"
 certifi = ">=2022.5.18,<2024.0.0"
 


### PR DESCRIPTION
There are two release channels for urllib3: 1.x and 2.x. Right now, we're on 1.x, and dependabot is trying to upgrade us to 2.x. However, this seems to be a pretty major jump that we need to fully test. For now, I'd like to keep us on 1.x. So, I'm adding this filter to make sure we keep getting updates on 1.x until we explore the impact of moving to 2.x.