### PR TITLE
Swap MACD signal and histogram values

### DIFF
--- a/polygon/rest/models/indicators.py
+++ b/polygon/rest/models/indicators.py
@@ -31,8 +31,8 @@ class MACDIndicatorValue:
         return MACDIndicatorValue(
             timestamp=d.get("timestamp", None),
             value=d.get("value", None),
-            signal=d.get("histogram", None),
-            histogram=d.get("signal", None),
+            signal=d.get("signal", None),
+            histogram=d.get("histogram", None),
         )
 
 


### PR DESCRIPTION
Fix https://github.com/polygon-io/client-python/issues/517 where signal and histogram are swapped in the returns values for MACD.