### PR TITLE
Update http status codes to retry request on

### DIFF
--- a/polygon/rest/base.py
+++ b/polygon/rest/base.py
@@ -54,8 +54,8 @@ class BaseClient:
         # https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry.RETRY_AFTER_STATUS_CODES
         retry_strategy = Retry(
             total=self.retries,
-            status_forcelist=[413, 429, 500, 502, 503, 504], # default 413, 429, 503
-            backoff_factor=0.1 # [0.0s, 0.2s, 0.4s, 0.8s, 1.6s, ...]
+            status_forcelist=[413, 429, 500, 502, 503, 504],  # default 413, 429, 503
+            backoff_factor=0.1,  # [0.0s, 0.2s, 0.4s, 0.8s, 1.6s, ...]
         )
 
         # https://urllib3.readthedocs.io/en/stable/reference/urllib3.poolmanager.html
@@ -65,7 +65,7 @@ class BaseClient:
             headers=self.headers,  # default headers sent with each request.
             ca_certs=certifi.where(),
             cert_reqs="CERT_REQUIRED",
-            retries=retry_strategy  # use the customized Retry instance
+            retries=retry_strategy,  # use the customized Retry instance
         )
 
         self.timeout = urllib3.Timeout(connect=connect_timeout, read=read_timeout)


### PR DESCRIPTION
Fixes https://github.com/polygon-io/client-python/issues/525.

If this update makes sense we should probably update the other client libraries with similar logic. Happy to have feedback here on if this PR makes sense.

Updated the existing retry logic by adding more HTTP status codes that should trigger a request retry. The default [urllib3 status codes to retry](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry.RETRY_AFTER_STATUS_CODES�) on are `413, 429, 503`. In this update, HTTP status codes to retry on has been updated to `413, 429, 500, 502, 503, 504` via the `status_forcelist` in the retry strategy, to accommodate a larger spectrum of server and client errors, especially those pertaining to temporary gateway or server issues.

Default status codes to retry on:
* 413: Request Entity Too Large
* 429: Too Many Requests
* 503: Service Unavailable

Added these status codes:
* 500: Internal Server Error
* 502: Bad Gateway
* 504: Gateway Timeout

Additionally, the `backoff_factor` was modified to `0.1` to facilitate a gradual backoff between retries using `0.0s, 0.2s, 0.4s, 0.8s, 1.6s, ...`. These modifications aim to improve the client retry logic against transient server problems and reliability of the client's HTTP requests in various situations.

