### PR TITLE
changed logic in parse subscription to handle class designation

### DIFF
--- a/polygon/websocket/__init__.py
+++ b/polygon/websocket/__init__.py
@@ -204,18 +204,16 @@ class WebSocketClient:
         split = s.split(".")
         length = len(split)
 
-        match length:
-            case _ if length < 2: 
-                logger.warning("invalid subscription:", s)      
-                return [None, None]
-            case 3:
-                return split[0], split[1] + "." + split[2]
-            case _ if length > 3:
-                logger.warning("invalid subscription:", s)
-                return [None, None]
-            case _:
-                return split[0], split[1]
-
+        if length < 2:
+            logger.warning("invalid subscription:", s)  
+            return [None, None]
+        if length == 2:
+            return split[0], split[1]
+        if length == 3:
+            return split[0], split[1] + "." + split[2]
+        if length > 3:
+            logger.warning("invalid subscription:", s)  
+            return [None, None]
 
 
     def subscribe(self, *subscriptions: str):

--- a/polygon/websocket/__init__.py
+++ b/polygon/websocket/__init__.py
@@ -197,15 +197,26 @@ class WebSocketClient:
             self.json.dumps({"action": "unsubscribe", "params": subs})
         )
 
+
     @staticmethod
     def _parse_subscription(s: str):
         s = s.strip()
         split = s.split(".")
-        if len(split) != 2:
-            logger.warning("invalid subscription:", s)
-            return [None, None]
+        length = len(split)
 
-        return split
+        match length:
+            case _ if length < 2: 
+                logger.warning("invalid subscription:", s)      
+                return [None, None]
+            case 3:
+                return split[0], split[1] + "." + split[2]
+            case _ if length > 3:
+                logger.warning("invalid subscription:", s)
+                return [None, None]
+            case _:
+                return split[0], split[1]
+
+
 
     def subscribe(self, *subscriptions: str):
         """


### PR DESCRIPTION
issue [1474](https://app.zenhub.com/workspaces/backend-support-6042935fc77665000f50780e/issues/gh/polygon-io/backend/1474).  Customer was passing in a Class B designation on subscription/ticker string. The client side validation was unable to handle that. Correct fix is the change the subscribe method to take args as opposed to a string that we have to parse. But that would be a breaking change.