### PR TITLE
Retry on 499 status code

### DIFF
--- a/polygon/rest/base.py
+++ b/polygon/rest/base.py
@@ -54,7 +54,7 @@ class BaseClient:
         # https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry.RETRY_AFTER_STATUS_CODES
         retry_strategy = Retry(
             total=self.retries,
-            status_forcelist=[413, 429, 500, 502, 503, 504],  # default 413, 429, 503
+            status_forcelist=[413, 429, 499, 500, 502, 503, 504],  # default 413, 429, 503
             backoff_factor=0.1,  # [0.0s, 0.2s, 0.4s, 0.8s, 1.6s, ...]
         )
 

--- a/polygon/rest/base.py
+++ b/polygon/rest/base.py
@@ -54,7 +54,15 @@ class BaseClient:
         # https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry.RETRY_AFTER_STATUS_CODES
         retry_strategy = Retry(
             total=self.retries,
-            status_forcelist=[413, 429, 499, 500, 502, 503, 504],  # default 413, 429, 503
+            status_forcelist=[
+                413,
+                429,
+                499,
+                500,
+                502,
+                503,
+                504,
+            ],  # default 413, 429, 503
             backoff_factor=0.1,  # [0.0s, 0.2s, 0.4s, 0.8s, 1.6s, ...]
         )
 


### PR DESCRIPTION
Added a retry on 499 error code. Reading the docs this seems like a request timeout issue where the connection gets closed. It seems like a special code for nginx similar to gateway timed out but on the client side where they close it after waiting too long. We should retry on this.