### PR TITLE
Fix websocket parse of tickers with periods

### DIFF
--- a/polygon/websocket/__init__.py
+++ b/polygon/websocket/__init__.py
@@ -200,7 +200,7 @@ class WebSocketClient:
     @staticmethod
     def _parse_subscription(s: str):
         s = s.strip()
-        split = s.split(".")
+        split = s.split(".", 1)  # Split at the first period
         if len(split) != 2:
             logger.warning("invalid subscription:", s)
             return [None, None]


### PR DESCRIPTION
Fixes polygon-io/backend/1474. Tickers like `BRK.B` were not getting parsed correctly. Changed to logic to only split on the first period and then pass along everything else. https://github.com/polygon-io/client-python/pull/559 has another potential fix but I prefer this once since the overall intention is to split out the event topic and the ticker symbol.

I've tested this and it works as expected:

```
2023-11-27 13:56:19,066 WebSocketClient DEBUG: sub desired: T.BRK.B
2023-11-27 13:56:19,066 WebSocketClient DEBUG: connect: wss://socket.polygon.io/stocks
2023-11-27 13:56:19,432 WebSocketClient DEBUG: connected: [{"ev":"status","status":"connected","message":"Connected Successfully"}]
2023-11-27 13:56:19,432 WebSocketClient DEBUG: authing...
2023-11-27 13:56:19,517 WebSocketClient DEBUG: authed: [{"ev":"status","status":"auth_success","message":"authenticated"}]
2023-11-27 13:56:19,517 WebSocketClient DEBUG: reconciling: set() {'T.BRK.B'}
2023-11-27 13:56:19,517 WebSocketClient DEBUG: subbing: T.BRK.B
2023-11-27 13:56:19,599 WebSocketClient DEBUG: status: subscribed to: T.BRK.B

EquityTrade(event_type='T', symbol='BRK.B', exchange=4, id='71701683064399', tape=1, price=361.34, size=22949, conditions=[12, 22], timestamp=1701122716429, sequence_number=3111734, trf_id=202, trf_timestamp=1701122716428)
EquityTrade(event_type='T', symbol='BRK.B', exchange=4, id='71701683064627', tape=1, price=361.34, size=6, conditions=[12, 37], timestamp=1701122719469, sequence_number=3111736, trf_id=202, trf_timestamp=1701122719469)
```

Also tested with the current examples and nothing breaks.