### PR TITLE
Update README.md with setuptools

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,20 @@
 
 Welcome to the official Python client library for the [Polygon](https://polygon.io/) REST and WebSocket API. To get started, please see the [Getting Started](https://polygon.io/docs/stocks/getting-started) section in our documentation, view the [examples](./examples/) directory for code snippets, or the [blog post](https://polygon.io/blog/polygon-io-with-python-for-stock-market-data/) with video tutorials to learn more.
 
+## Prerequisites
+
+Before installing the Polygon Python client, ensure your environment has Python 3.8 or higher. While most Python environments come with setuptools installed, it is a dependency for this library. In the rare case it's not already present, you can install setuptools using pip:
+
+```
+pip install setuptools
+```
+
 ## Install
 
 Please use pip to install or update to the latest stable version.
 ```
 pip install -U polygon-api-client
 ```
-Requires Python >= 3.8.
 
 ## Getting started
 


### PR DESCRIPTION
Fixes https://github.com/polygon-io/client-python/issues/593.

Updated installation documentation to include a note on setuptools dependency, ensuring comprehensive guidance for all user environments. `setuptools` is a key package in Python used for building, distributing, and installing packages. It is not part of the Python Standard Library, but it is included with most Python distributions, such as the official Python distributions from python.org, Anaconda, and others.

For most users, especially those using Python distributions intended for application development and data science, setuptools will be pre-installed, making it seem like it's a default part of Python. However, in minimal or custom Python environments, setuptools might not be included by default and may need to be installed separately using package management tools like pip.