### PR TITLE
Add API key usage note to Getting Started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ pip install -U polygon-api-client
 
 To get started, please see the [Getting Started](https://polygon-api-client.readthedocs.io/en/latest/Getting-Started.html) section in our docs, view the [examples](./examples) directory for code snippets, or view the [blog post with videos](https://polygon.io/blog/polygon-io-with-python-for-stock-market-data/) to learn more.
 
+When using a free API key, please be mindful that it supports up to 5 API calls per minute. Exceeding this limit will throw an error message related to rate limits. For uninterrupted access and higher limits, consider upgrading to our [Starter plan](https://polygon.io/pricing), which offers unlimited API calls. This ensures a smoother experience, especially when working with real-time data or building applications that require higher request volumes.
+
 ## REST API Client
 Import the RESTClient.
 ```python

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install -U polygon-api-client
 
 To get started, please see the [Getting Started](https://polygon-api-client.readthedocs.io/en/latest/Getting-Started.html) section in our docs, view the [examples](./examples) directory for code snippets, or view the [blog post with videos](https://polygon.io/blog/polygon-io-with-python-for-stock-market-data/) to learn more.
 
-When using a free API key, please be mindful that it supports up to 5 API calls per minute. Exceeding this limit will throw an error message related to rate limits. For uninterrupted access and higher limits, consider upgrading to our [Starter plan](https://polygon.io/pricing), which offers unlimited API calls. This ensures a smoother experience, especially when working with real-time data or building applications that require higher request volumes.
+The free tier of our API comes with usage limitations, potentially leading to rate limit errors if these are exceeded. For uninterrupted access and to support larger data requirements, we recommend reviewing our [subscription plans](https://polygon.io/pricing), which are tailored for a wide range of needs from development to high-demand applications. Refer to our pricing page for detailed information on limits and features to ensure a seamless experience, especially for real-time data processing.
 
 ## REST API Client
 Import the RESTClient.


### PR DESCRIPTION
Fixes https://github.com/polygon-io/client-python/issues/594.

This PR updates the Getting Started section to include a note on the limitations of free API keys and encourages upgrading for higher limits. It aims to enhance user awareness about potential throttling and improve their experience with proactive guidance.