### PR TITLE
Add to_dict method to modelclass

### DIFF
--- a/polygon/modelclass.py
+++ b/polygon/modelclass.py
@@ -1,9 +1,10 @@
 import inspect
 import typing
-from dataclasses import dataclass
+from dataclasses import dataclass, asdict
 
 
 _T = typing.TypeVar("_T")
+
 
 
 def modelclass(cls: typing.Type[_T]) -> typing.Type[_T]:
@@ -22,6 +23,10 @@ def modelclass(cls: typing.Type[_T]) -> typing.Type[_T]:
             if k in attributes:
                 self.__dict__[k] = v
 
+    def to_dict(self):
+        return asdict(self)
+
     cls.__init__ = init  # type: ignore[assignment]
+    cls.to_dict = to_dict  # Add to_dict method to the class
 
     return cls


### PR DESCRIPTION
This pull request adds a `to_dict` method to the `modelclass` function. The `to_dict` method converts an instance of the class to a dictionary representation. This can be useful for serialization or other operations that require a dictionary representation of the object.