### PR TITLE
Use ssl_context for HTTPS requests to avoid reading certificate files on every request

### DIFF
--- a/polygon/rest/base.py
+++ b/polygon/rest/base.py
@@ -67,6 +67,7 @@ class BaseClient:
             backoff_factor=0.1,  # [0.0s, 0.2s, 0.4s, 0.8s, 1.6s, ...]
         )
 
+        # global cache ssl context and use (vs on each init of pool manager)
         ssl_context = ssl.create_default_context()
         ssl_context.load_verify_locations(certifi.where())
 

--- a/polygon/rest/base.py
+++ b/polygon/rest/base.py
@@ -1,5 +1,6 @@
 import certifi
 import json
+import ssl
 import urllib3
 import inspect
 from urllib3.util.retry import Retry
@@ -66,13 +67,15 @@ class BaseClient:
             backoff_factor=0.1,  # [0.0s, 0.2s, 0.4s, 0.8s, 1.6s, ...]
         )
 
+        ssl_context = ssl.create_default_context()
+        ssl_context.load_verify_locations(certifi.where())
+
         # https://urllib3.readthedocs.io/en/stable/reference/urllib3.poolmanager.html
         # https://urllib3.readthedocs.io/en/stable/reference/urllib3.connectionpool.html#urllib3.HTTPConnectionPool
         self.client = urllib3.PoolManager(
             num_pools=num_pools,
             headers=self.headers,  # default headers sent with each request.
-            ca_certs=certifi.where(),
-            cert_reqs="CERT_REQUIRED",
+            ssl_context=ssl_context,
             retries=retry_strategy,  # use the customized Retry instance
         )
 


### PR DESCRIPTION
Pull request for the issue I opened here: https://github.com/polygon-io/client-python/issues/631
