### PR TITLE
Add CGI to MarketIndices

### DIFF
--- a/polygon/rest/models/markets.py
+++ b/polygon/rest/models/markets.py
@@ -30,6 +30,7 @@ class MarketIndices:
     "Contains indices market status data."
     s_and_p: Optional[str] = None
     societe_generale: Optional[str] = None
+    cgi: Optional[str] = None
     msci: Optional[str] = None
     ftse_russell: Optional[str] = None
     mstar: Optional[str] = None


### PR DESCRIPTION
CBOE recently added the CGI (CBOE Global Indices) feed, and as a result it was added to the Market Status endpoint.