### PR TITLE
Update base.py to remove setuptools and use standard library

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,7 @@ Welcome to the official Python client library for the [Polygon](https://polygon.
 
 ## Prerequisites
 
-Before installing the Polygon Python client, ensure your environment has Python 3.8 or higher. While most Python environments come with setuptools installed, it is a dependency for this library. In the rare case it's not already present, you can install setuptools using pip:
-
-```
-pip install setuptools
-```
+Before installing the Polygon Python client, ensure your environment has Python 3.8 or higher.
 
 ## Install
 

--- a/polygon/rest/base.py
+++ b/polygon/rest/base.py
@@ -46,7 +46,7 @@ class BaseClient:
         self.headers = {
             "Authorization": "Bearer " + self.API_KEY,
             "Accept-Encoding": "gzip",
-            "User-Agent": f"Polygon.io PythonClient/{version}",
+            "User-Agent": f"Polygon.io PythonClient/{version_number}",
         }
 
         # initialize self.retries with the parameter value before using it

--- a/polygon/rest/base.py
+++ b/polygon/rest/base.py
@@ -7,7 +7,7 @@ from urllib3.util.retry import Retry
 from enum import Enum
 from typing import Optional, Any, Dict
 from datetime import datetime
-import pkg_resources  # part of setuptools
+from importlib.metadata import version, PackageNotFoundError
 from .models.request import RequestOptionBuilder
 from ..logging import get_logger
 import logging
@@ -15,10 +15,10 @@ from urllib.parse import urlencode
 from ..exceptions import AuthError, BadResponse
 
 logger = get_logger("RESTClient")
-version = "unknown"
+version_number = "unknown"
 try:
-    version = pkg_resources.require("polygon-api-client")[0].version
-except:
+    version_number = version("polygon-api-client")
+except PackageNotFoundError:
     pass
 
 


### PR DESCRIPTION
This PR updates the method for retrieving the version number of the `polygon-api-client` package. It replaces the use of `pkg_resources` from `setuptools` with `importlib.metadata`, which is part of the standard library in Python 3.8 and newer.

## Changes
- Removed `import pkg_resources` and replaced it with `from importlib.metadata import version, PackageNotFoundError`.
- Updated the version retrieval logic to use `importlib.metadata.version` instead of `pkg_resources.require`.

## Benefits
- Reduces external dependency on `setuptools` which is deprecated and causing issues (https://github.com/polygon-io/client-python/issues/693 & https://github.com/polygon-io/client-python/issues/593)
- Utilizes the standard library, improving compatibility and reducing overhead.