### PR TITLE
Fix example to have correct params

### DIFF
--- a/examples/rest/raw-list.py
+++ b/examples/rest/raw-list.py
@@ -6,7 +6,7 @@ client = RESTClient()
 
 trades = cast(
     HTTPResponse,
-    client.list_trades("AAA", "2022-04-20", 5, raw=True),
+    client.list_trades("AAA", "2022-04-20", raw=True),
 )
 print(trades.data)
 # b'{


### PR DESCRIPTION
Fixed the example to have the correct params. You cannot pass date eq (`timestamp=`) with a less than (`timestamp.lt=`). It needs to be either or.

```
polygon.exceptions.BadResponse: {"status":"ERROR","request_id":"71f9a7ec439a46e7884c38c893daddcc","error":"failed to parse timestamp query params: query parameters cannot have the combination of equal and any other param gt, gte, lt, lte"}
```

Fixed the example to just pass the date.