### PR TITLE
Websocket.run() await handle_msg()

### DIFF
--- a/polygon/websocket/__init__.py
+++ b/polygon/websocket/__init__.py
@@ -175,7 +175,7 @@ class WebSocketClient:
         """
 
         async def handle_msg_wrapper(msgs):
-            handle_msg(msgs)
+            await handle_msg(msgs)
 
         asyncio.run(self.connect(handle_msg_wrapper, close_timeout, **kwargs))
 


### PR DESCRIPTION
Async functions cannot be used for handle_msg() because' await' is never called. The wrapper is marked as async, so I would expect await to be called. This results in a RuntimeWarning because the passed function never gets executed.

Message from runtime.

``` 
/home/developer/.cache/bazel/_bazel_developer/646bcbb063181c5dac5a581e1c4fefdd/execroot/_main/bazel-out/k8-fastbuild/bin/environments/polygon_api.runfiles/rules_python~~pip~rogue_trading_python_dependencies_311_polygon_api_client/site-packages/polygon/websocket/__init__.py:178: 
RuntimeWarning: coroutine 'PolygonAPI.send_to_database' was never awaited
  handle_msg(msgs)
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```