### PR TITLE
Update Universal Snapshot 'session' model

### DIFF
--- a/polygon/rest/models/snapshot.py
+++ b/polygon/rest/models/snapshot.py
@@ -308,6 +308,8 @@ class UniversalSnapshotSession:
     change_percent: Optional[float] = None
     early_trading_change: Optional[float] = None
     early_trading_change_percent: Optional[float] = None
+    regular_trading_change: Optional[float] = None
+    regular_trading_change_percent: Optional[float] = None
     late_trading_change: Optional[float] = None
     late_trading_change_percent: Optional[float] = None
     open: Optional[float] = None


### PR DESCRIPTION
We recently added `regular_trading_change` and `regular_trading_change_percent` to this response, which represents the change in the asset between its open and close.