### PR TITLE
Update pyproject.toml Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,5 @@ target/
 
 #Ipython Notebook
 .ipynb_checkpoints
+
+menv/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polygon-api-client"
-version = "0.0.0"
+version = "1.14.2"
 description = "Official Polygon.io REST and Websocket client."
 authors = ["polygon.io"]
 license = "MIT"


### PR DESCRIPTION
By updating the pyproject.toml file to the current latest version when we install the project we can now get the correct web sockets dependency for installation in other packages.