### PR TITLE
Add Diluted EPS(Earnings-Per-Share)

### DIFF
--- a/polygon/rest/models/financials.py
+++ b/polygon/rest/models/financials.py
@@ -1,7 +1,6 @@
 from typing import Optional, Dict
 from ...modelclass import modelclass
 
-
 @modelclass
 class DataPoint:
     "An individual financial data point."
@@ -15,7 +14,6 @@ class DataPoint:
     @staticmethod
     def from_dict(d):
         return DataPoint(**d)
-
 
 @modelclass
 class ExchangeGainsLosses:
@@ -31,7 +29,6 @@ class ExchangeGainsLosses:
     def from_dict(d):
         return ExchangeGainsLosses(**d)
 
-
 @modelclass
 class NetCashFlow:
     "Contains net cash flow data for a cash flow statement."
@@ -46,7 +43,6 @@ class NetCashFlow:
     def from_dict(d):
         return NetCashFlow(**d)
 
-
 @modelclass
 class NetCashFlowFromFinancingActivities:
     "Contains net cash flow from financing activities data for a cash flow statement."
@@ -60,7 +56,6 @@ class NetCashFlowFromFinancingActivities:
     @staticmethod
     def from_dict(d):
         return NetCashFlowFromFinancingActivities(**d)
-
 
 @modelclass
 class CashFlowStatement:
@@ -93,7 +88,6 @@ class CashFlowStatement:
             ),
         )
 
-
 @modelclass
 class ComprehensiveIncomeLoss:
     "Contains comprehensive income loss data for comprehensive income."
@@ -107,7 +101,6 @@ class ComprehensiveIncomeLoss:
     @staticmethod
     def from_dict(d):
         return ComprehensiveIncomeLoss(**d)
-
 
 @modelclass
 class ComprehensiveIncomeLossAttributableToParent:
@@ -123,7 +116,6 @@ class ComprehensiveIncomeLossAttributableToParent:
     def from_dict(d):
         return ComprehensiveIncomeLossAttributableToParent(**d)
 
-
 @modelclass
 class OtherComprehensiveIncomeLoss:
     "Contains other comprehensive income loss data for comprehensive income."
@@ -137,7 +129,6 @@ class OtherComprehensiveIncomeLoss:
     @staticmethod
     def from_dict(d):
         return OtherComprehensiveIncomeLoss(**d)
-
 
 @modelclass
 class ComprehensiveIncome:
@@ -172,7 +163,6 @@ class ComprehensiveIncome:
             ),
         )
 
-
 @modelclass
 class BasicEarningsPerShare:
     "Contains basic earning per share data for an income statement."
@@ -187,6 +177,19 @@ class BasicEarningsPerShare:
     def from_dict(d):
         return BasicEarningsPerShare(**d)
 
+@modelclass
+class DilutedEarningsPerShare:
+    "Contains diluted earnings per share data for an income statement."
+    formula: Optional[str] = None
+    label: Optional[str] = None
+    order: Optional[int] = None
+    unit: Optional[str] = None
+    value: Optional[float] = None
+    xpath: Optional[str] = None
+
+    @staticmethod
+    def from_dict(d):
+        return DilutedEarningsPerShare(**d)
 
 @modelclass
 class CostOfRevenue:
@@ -202,7 +205,6 @@ class CostOfRevenue:
     def from_dict(d):
         return CostOfRevenue(**d)
 
-
 @modelclass
 class GrossProfit:
     "Contains gross profit data for an income statement."
@@ -216,7 +218,6 @@ class GrossProfit:
     @staticmethod
     def from_dict(d):
         return GrossProfit(**d)
-
 
 @modelclass
 class OperatingExpenses:
@@ -232,7 +233,6 @@ class OperatingExpenses:
     def from_dict(d):
         return OperatingExpenses(**d)
 
-
 @modelclass
 class Revenues:
     "Contains revenues data for an income statement."
@@ -247,11 +247,11 @@ class Revenues:
     def from_dict(d):
         return Revenues(**d)
 
-
 @modelclass
 class IncomeStatement:
     "Contains income statement data."
     basic_earnings_per_share: Optional[BasicEarningsPerShare] = None
+    diluted_earnings_per_share: Optional[DilutedEarningsPerShare] = None
     cost_of_revenue: Optional[CostOfRevenue] = None
     gross_profit: Optional[GrossProfit] = None
     operating_expenses: Optional[OperatingExpenses] = None
@@ -264,6 +264,11 @@ class IncomeStatement:
                 None
                 if "basic_earnings_per_share" not in d
                 else BasicEarningsPerShare.from_dict(d["basic_earnings_per_share"])
+            ),
+            diluted_earnings_per_share=(
+                None
+                if "diluted_earnings_per_share" not in d
+                else DilutedEarningsPerShare.from_dict(d["diluted_earnings_per_share"])
             ),
             cost_of_revenue=(
                 None
@@ -282,7 +287,6 @@ class IncomeStatement:
             ),
             revenues=None if "revenues" not in d else Revenues.from_dict(d["revenues"]),
         )
-
 
 @modelclass
 class Financials:
@@ -318,7 +322,6 @@ class Financials:
                 else IncomeStatement.from_dict(d["income_statement"])
             ),
         )
-
 
 @modelclass
 class StockFinancial:

--- a/test_rest/test_financials.py
+++ b/test_rest/test_financials.py
@@ -12,6 +12,7 @@ from polygon.rest.models import (
     OtherComprehensiveIncomeLoss,
     IncomeStatement,
     BasicEarningsPerShare,
+    DilutedEarningsPerShare,  
     CostOfRevenue,
     GrossProfit,
     OperatingExpenses,
@@ -187,6 +188,14 @@ class FinancialsTest(BaseTest):
                             order=4200,
                             unit="USD / shares",
                             value=2.5,
+                            xpath=None,
+                        ),
+                        diluted_earnings_per_share=DilutedEarningsPerShare(  
+                            formula=None,
+                            label="Diluted Earnings Per Share",
+                            order=4300,
+                            unit="USD / shares",
+                            value=2.3,
                             xpath=None,
                         ),
                         cost_of_revenue=CostOfRevenue(


### PR DESCRIPTION
Fixes #792 

This pull request includes changes to the `polygon/rest/models/financials.py` file, primarily focusing on the addition of `DilutedEarningsPerShare` and the inclusion of this in the `IncomeStatement` class. Additionally, there are corresponding updates to the test file `test_rest/test_financials.py`.

### New Class Addition:

* Added a new class `DilutedEarningsPerShare` to represent diluted earnings per share data for an income statement. This class includes the standard attributes I saw: `formula`, `label`, `order`, `unit`, `value`, and `xpath`, along with a `from_dict` method.

### Updates to Existing Classes:

* Updated the `IncomeStatement` class to include an optional `diluted_earnings_per_share` attribute.
* Modified the `from_dict` method of the `IncomeStatement` class to handle the new `diluted_earnings_per_share` attribute.

### Test Updates:

* Added `DilutedEarningsPerShare` to the import statements in the `test_rest/test_financials.py` file.
* Updated the `test_list_stock_financials` method to test the new `diluted_earnings_per_share` attribute in the `IncomeStatement` class.