### PR TITLE
Update requirements.txt to allow newer websockets package

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
 sphinx-autodoc-typehints~=1.19.2
-websockets~=10.3
+websockets>=10.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.8"
 urllib3 = ">=1.26.9,<3.0.0"
-websockets = ">=10.3,<14.0"
+websockets = ">=10.3,<15.0"
 certifi = ">=2022.5.18,<2025.0.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "polygon-api-client"
-version = "0.0.0"
+version = "2.0.0"
 description = "Official Polygon.io REST and Websocket client."
 authors = ["polygon.io"]
 license = "MIT"


### PR DESCRIPTION
Currently missing out on improvements from newer websocket package. This old dependency also conflicts 3rd party requirements when being used in a large python project with modern dependencies.

Confirmed websockets and REST API working for equities, forex, and crypto