### PR TITLE
Remove limits for websockets and urllib3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-urllib3 = ">=1.26.9,<3.0.0"
-websockets = ">=10.3,<15.0"
+urllib3 = ">=1.26.9"
+websockets = ">=10.3"
 certifi = ">=2022.5.18,<2026.0.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Fixes https://github.com/polygon-io/client-python/issues/887. Removing the upper bounds on websockets and urllib3 so that dependabot can suggest updates. Right now, there are urllib3 security updates that we're not getting.